### PR TITLE
ci(automatic-rebase): use token for checkout

### DIFF
--- a/.github/workflows/automatic-rebase.yaml
+++ b/.github/workflows/automatic-rebase.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Automatic rebase


### PR DESCRIPTION
It was necessary.