### PR TITLE
feat: add sync-files action

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -1,0 +1,11 @@
+- repository: autowarefoundation/autoware
+  files:
+    - source: .github/dependabot.yaml
+    - source: .github/workflows/pre-commit-optional.yaml
+    - source: .github/workflows/spell-check.yaml
+    - source: .markdown-link-check.json
+    - source: .markdownlint.yaml
+    - source: .pre-commit-config-optional.yaml
+    - source: .prettierignore
+    - source: .prettierrc.yaml
+    - source: .yamllint.yaml

--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -1,0 +1,22 @@
+name: sync-files
+
+on:
+  schedule:
+    - cron: 0 19 * * * # run at 4 AM JST
+  workflow_dispatch:
+
+jobs:
+  sync-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run sync-files
+        uses: autowarefoundation/autoware-github-actions/sync-files@tier4/proposal
+        with:
+          token: ${{ steps.generate-token.outputs.token }}

--- a/sync-files/README.md
+++ b/sync-files/README.md
@@ -1,0 +1,81 @@
+# sync-files
+
+## Description
+
+This action syncs files between repositories.  
+It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests.
+
+Note that you need `workflow` permission for the token if you copy workflow files of GitHub Actions.
+
+## Usage
+
+```yaml
+jobs:
+  sync-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run sync-files
+        uses: autowarefoundation/autoware-github-actions/sync-files@tier4/proposal
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+```
+
+Please place `.github/sync-files.yaml` like this.
+
+```yaml
+- repository: autowarefoundation/autoware
+  files:
+    - source: .github/dependabot.yaml
+```
+
+The specifications are:
+
+- The settings for each repository are listed at the top level.
+
+  ```yaml
+  - repository: org1/repo1
+    files: ...
+
+  - repository: org1/repo2
+    files: ...
+
+  - repository: org2/repo
+    files: ...
+  ```
+
+- The data format for each repository is the following.
+
+| Name                  | Required | Default                                      | Description                                                                              |
+| --------------------- | -------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| repository            | true     | -                                            | The target repository.                                                                   |
+| ref                   | false    | The default branch of the target repository. | The version of the target repository.                                                    |
+| files/source          | true     | -                                            | The path to the file in the target repository.                                           |
+| files/dest            | false    | The same as `files/source`.                  | The path where to place the synced file in the base repository.                          |
+| files/replace         | false    | `true`                                       | Whether to replace the synced file if it already exists.                                 |
+| files/delete-orphaned | false    | `true`                                       | Whether to delete the synced file if it does not exist in the target repository anymore. |
+
+## Inputs
+
+| Name              | Required | Description                                   |
+| ----------------- | -------- | --------------------------------------------- |
+| token             | true     | The token for pull requests.                  |
+| config            | false    | The path to `sync-files.yaml`.                |
+| pr-base           | false    | Please see `peter-evans/create-pull-request`. |
+| pr-branch         | false    | The same as above.                            |
+| pr-title          | false    | The same as above.                            |
+| pr-commit-message | false    | The same as above.                            |
+| pr-body           | false    | The same as above.                            |
+| pr-labels         | false    | The same as above.                            |
+| pr-assignees      | false    | The same as above.                            |
+| pr-reviewers      | false    | The same as above.                            |
+
+## Outputs
+
+None.

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -1,0 +1,132 @@
+name: sync-files
+description: ""
+
+inputs:
+  token:
+    description: ""
+    required: true
+  config:
+    description: ""
+    required: false
+    default: .github/sync-files.yaml
+  pr-base:
+    description: ""
+    required: false
+    default: ${{ github.event.repository.default_branch }}
+  pr-branch:
+    description: ""
+    required: false
+    default: sync-files
+  pr-title:
+    description: ""
+    required: false
+    default: "chore: sync files"
+  pr-commit-message:
+    description: ""
+    required: false
+    default: "chore: sync files"
+  pr-body:
+    description: ""
+    required: false
+    default: ""
+  pr-labels:
+    description: ""
+    required: false
+    default: ""
+  pr-assignees:
+    description: ""
+    required: false
+    default: ""
+  pr-reviewers:
+    description: ""
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Set up yq
+      uses: chrisdickinson/setup-yq@v1.0.1
+      with:
+        yq-version: v4.17.2
+
+    - name: Parse config
+      run: |
+        pip3 install pyyaml
+
+        cat ${{ inputs.config }}
+        python3 ${GITHUB_ACTION_PATH}/parse_config.py ${{ inputs.config }} > /tmp/sync-files.yaml
+        cat /tmp/sync-files.yaml
+      shell: bash
+
+    - name: Sync files
+      run: |
+        set -e
+
+        for repository in $(yq e ".[].repository" /tmp/sync-files.yaml); do
+          yq e ".[] | select(.repository == \"$repository\")" /tmp/sync-files.yaml > /tmp/repo-config.yaml
+
+          ref=$(yq e ".ref" /tmp/repo-config.yaml)
+
+          git_options=()
+          if [ "$ref" != "" ]; then
+            git_options+=("-b $ref")
+          fi
+
+          rm -rf /tmp/repository
+          git clone "$repository" /tmp/repository ${git_options[@]}
+
+          for source_file in $(yq e ".files[].source" /tmp/repo-config.yaml); do
+            yq e ".files[] | select(.source == \"$source_file\")" /tmp/repo-config.yaml > /tmp/file-config.yaml
+
+            source_path=$(yq e ".source" /tmp/file-config.yaml)
+            dest_path=$(yq e ".dest" /tmp/file-config.yaml)
+            replace=$(yq e ".replace" /tmp/file-config.yaml)
+            delete_orphaned=$(yq e ".delete-orphaned" /tmp/file-config.yaml)
+
+            target_file="/tmp/repository/$source_path"
+            if [ -f "$target_file" ]; then
+              if [ -f "$dest_file" ] && [ "replace" != "true" ]; then
+                echo "Skip copying to $dest_file."
+                continue
+              fi
+
+              echo "Copy $source_path to $dest_path."
+              cp "$target_file" "$dest_path"
+            elif [ "$delete_orphaned" = "true" ]; then
+              echo "Delete $dest_path."
+              rm "$dest_path" || true
+            fi
+          done
+        done
+
+        git status
+      shell: bash
+
+    - name: Create PR
+      id: create-pr
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ inputs.token }}
+        base: ${{ inputs.pr-base }}
+        branch: ${{ inputs.pr-branch }}
+        title: ${{ inputs.pr-title }}
+        commit-message: ${{ inputs.pr-commit-message }}
+        body: ${{ inputs.pr-body }}
+        labels: ${{ inputs.pr-labels }}
+        assignees: ${{ inputs.pr-assignees }}
+        reviewers: ${{ inputs.pr-reviewers }}
+        signoff: true
+        delete-branch: true
+
+    - name: Check outputs
+      run: |
+        echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"
+      shell: bash

--- a/sync-files/parse_config.py
+++ b/sync-files/parse_config.py
@@ -1,0 +1,40 @@
+import argparse
+import re
+from pathlib import Path
+
+import yaml
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config_file")
+    args = parser.parse_args()
+
+    with Path(args.config_file).open() as f:
+        config = yaml.safe_load(f)
+
+    for repo_config in config:
+        if not re.match(r"^http", repo_config["repository"]):
+            repo_config["repository"] = f"https://github.com/{repo_config['repository']}.git"
+
+        if not repo_config.get("ref"):
+            repo_config["ref"] = ""
+
+        for item in repo_config["files"]:
+            if not item.get("source"):
+                raise RuntimeError(f"'source' is not defined in {item}")
+
+            if not item.get("dest"):
+                item["dest"] = item["source"]
+
+            if not item.get("replace"):
+                item["replace"] = True
+
+            if not item.get("delete-orphaned"):
+                item["delete-orphaned"] = True
+
+    print(yaml.dump(config))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Since Autoware has multiple repositories, it's useful to sync files between repositories to keep their settings the same.

[BetaHuhn/repo-file-sync-action](https://github.com/BetaHuhn/repo-file-sync-action) or [kbrashears5/github-action-file-sync](https://github.com/kbrashears5/github-action-file-sync) is useful for this use case, which I think we can call `push-style` action.

However, I'd like to add a `pull-style` action.
It's useful when a contributor has an Autoware's extension repository and doesn't want to manage a central repository for the settings like https://github.com/BetaHuhn/github-files or https://github.com/kbrashears5/kbrashears5.

Regarding the sync of community health files, We can consider using `.github` repository.
https://docs.github.com/ja/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file