### PR TITLE
feat(colcon-build-and-test): add coverage-related commands

### DIFF
--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -51,21 +51,30 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon build --event-handlers console_cohesion+ \
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
-          --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          --cmake-args \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage -DCOVERAGE_RUN=1" \
+            -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -DCOVERAGE_RUN=1" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       shell: bash
 
     - name: Test
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
+        colcon lcov-result --initial
         colcon test --event-handlers console_cohesion+ \
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
+        colcon lcov-result
+        colcon coveragepy-result
       shell: bash
 
-    - name: Cache build files for Clang-Tidy
+    - name: Cache build artifacts
       uses: actions/cache@v2
       with:
         path: |
           ./build
           ./install
+          ./lcov
+          ./coveragepy
         key: build-${{ github.sha }}

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -58,10 +58,9 @@ runs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       shell: bash
 
-    - name: Install python package for coverage commands
+    - name: Install Python packages for coverage commands
       run: |
-        pip3 install colcon-lcov-result
-        pip3 install colcon-coveragepy-result
+        pip3 install colcon-lcov-result colcon-coveragepy-result
       shell: bash
 
     - name: Test

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -58,6 +58,12 @@ runs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       shell: bash
 
+    - name: Install python package for coverage commands
+      run: |
+        pip3 install colcon-lcov-result
+        pip3 install colcon-coveragepy-result
+      shell: bash
+
     - name: Test
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -53,8 +53,8 @@ runs:
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
           --cmake-args \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage -DCOVERAGE_RUN=1" \
-            -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -DCOVERAGE_RUN=1" \
+            -DCMAKE_C_FLAGS="--coverage -DCOVERAGE_RUN=1" \
+            -DCMAKE_CXX_FLAGS="--coverage -DCOVERAGE_RUN=1" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       shell: bash
 


### PR DESCRIPTION
Added coverage related commands to `colcon-build-and-test` action.
Now I'm evaluating lcov and codecov workflows at https://github.com/KeisukeShima/autoware.universe/actions/runs/1738065485

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>

Related https://github.com/autowarefoundation/autoware.universe/issues/286