### PR TITLE
fix(colcon-build-and-test): add option to colcon lcov-result

### DIFF
--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -66,12 +66,15 @@ runs:
     - name: Test
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
-        colcon lcov-result --initial
+        colcon lcov-result --initial \
+          --packages-above ${{ inputs.target-packages }}
         colcon test --event-handlers console_cohesion+ \
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
-        colcon lcov-result
-        colcon coveragepy-result
+        colcon lcov-result \
+          --packages-above ${{ inputs.target-packages }}
+        colcon coveragepy-result \
+          --packages-above ${{ inputs.target-packages }}
       shell: bash
 
     - name: Cache build artifacts

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -66,15 +66,12 @@ runs:
     - name: Test
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
-        colcon lcov-result --initial \
-          --packages-above ${{ inputs.target-packages }}
+        colcon lcov-result --initial --packages-above ${{ inputs.target-packages }}
         colcon test --event-handlers console_cohesion+ \
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
-        colcon lcov-result \
-          --packages-above ${{ inputs.target-packages }}
-        colcon coveragepy-result \
-          --packages-above ${{ inputs.target-packages }}
+        colcon lcov-result --packages-above ${{ inputs.target-packages }}
+        colcon coveragepy-result --packages-above ${{ inputs.target-packages }}
       shell: bash
 
     - name: Cache build artifacts


### PR DESCRIPTION
Add `packages-above` option to `colcon lcov-result` and colcon `coveragepy-result`

This PR solves the error that occurs with `build-and-test-pr`.
https://github.com/autowarefoundation/autoware.universe/runs/4931225179?check_suite_focus=true

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>