### PR TITLE
fix(colcon-build-and-test): add lcov package

### DIFF
--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -58,8 +58,10 @@ runs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       shell: bash
 
-    - name: Install Python packages for coverage commands
+    - name: Install packages for coverage commands
       run: |
+        sudo apt-get -yqq update
+        sudo apt-get -yqq install lcov
         pip3 install colcon-lcov-result colcon-coveragepy-result
       shell: bash
 


### PR DESCRIPTION
Added a command to install the `lcov` package in order to run the `colcon lcov-result` command.

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>