### PR TITLE
fix(colcon-build-and-test): add file check statement and use colcon-mixin

### DIFF
--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -72,8 +72,10 @@ runs:
         colcon test --event-handlers console_cohesion+ \
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
-        (find build -name coverage.info | grep .) && colcon lcov-result --packages-above ${{ inputs.target-packages }}
-        colcon coveragepy-result --packages-above ${{ inputs.target-packages }}
+        if [ -n "$(find build/ -name coverage.info)" ]; then
+          colcon lcov-result --packages-above ${{ inputs.target-packages }}
+          colcon coveragepy-result --packages-above ${{ inputs.target-packages }}
+        fi
       shell: bash
 
     - name: Cache build artifacts

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -46,6 +46,12 @@ runs:
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths . --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 
+    - name: Set colcon-mixin-repository
+      run: |
+        colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+        colcon mixin update default
+      shell: bash
+
     - name: Build
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
@@ -53,10 +59,10 @@ runs:
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
           --cmake-args \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_FLAGS="--coverage -DCOVERAGE_RUN=1" \
-            -DCMAKE_CXX_FLAGS="--coverage -DCOVERAGE_RUN=1" \
+            -DCMAKE_C_FLAGS="-DCOVERAGE_RUN=1" \
+            -DCMAKE_CXX_FLAGS="-DCOVERAGE_RUN=1" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-          --ament-cmake-args -DAMENT_CMAKE_PYTEST_WITH_COVERAGE=ON
+          --mixin coverage-gcc coverage-pytest
       shell: bash
 
     - name: Install packages for coverage commands
@@ -71,8 +77,7 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon lcov-result --initial --packages-above ${{ inputs.target-packages }}
         colcon test --event-handlers console_cohesion+ \
-          --pytest-args " --cov-report=term" \
-          --pytest-with-coverage \
+          --mixin coverage-pytest \
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
         if [ -n "$(find build/ -name coverage.info)" ]; then

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -77,6 +77,8 @@ runs:
           --return-code-on-test-failure
         if [ -n "$(find build/ -name coverage.info)" ]; then
           colcon lcov-result --packages-above ${{ inputs.target-packages }}
+        fi
+        if [ -n "$(find build/ -name .coverage)" ]; then
           colcon coveragepy-result --packages-above ${{ inputs.target-packages }}
         fi
       shell: bash

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -46,7 +46,7 @@ runs:
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths . --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 
-    - name: Set colcon-mixin-repository
+    - name: Set up colcon-mixin
       run: |
         colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
         colcon mixin update default

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -72,7 +72,7 @@ runs:
         colcon test --event-handlers console_cohesion+ \
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
-        colcon lcov-result --packages-above ${{ inputs.target-packages }}
+        (find build -name coverage.info | grep .) && colcon lcov-result --packages-above ${{ inputs.target-packages }}
         colcon coveragepy-result --packages-above ${{ inputs.target-packages }}
       shell: bash
 

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -57,8 +57,7 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon build --event-handlers console_cohesion+ \
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
-          --cmake-args \
-            -DCMAKE_BUILD_TYPE=Release \
+          --cmake-args -DCMAKE_BUILD_TYPE=Release \
           --mixin coverage-gcc coverage-pytest compile-commands
       shell: bash
 

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -59,10 +59,7 @@ runs:
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
           --cmake-args \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_FLAGS="-DCOVERAGE_RUN=1" \
-            -DCMAKE_CXX_FLAGS="-DCOVERAGE_RUN=1" \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-          --mixin coverage-gcc coverage-pytest
+          --mixin coverage-gcc coverage-pytest compile-commands
       shell: bash
 
     - name: Install packages for coverage commands

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -55,7 +55,8 @@ runs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_FLAGS="--coverage -DCOVERAGE_RUN=1" \
             -DCMAKE_CXX_FLAGS="--coverage -DCOVERAGE_RUN=1" \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          --ament-cmake-args -DAMENT_CMAKE_PYTEST_WITH_COVERAGE=ON
       shell: bash
 
     - name: Install packages for coverage commands
@@ -70,6 +71,8 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon lcov-result --initial --packages-above ${{ inputs.target-packages }}
         colcon test --event-handlers console_cohesion+ \
+          --pytest-args " --cov-report=term" \
+          --pytest-with-coverage \
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
         if [ -n "$(find build/ -name coverage.info)" ]; then


### PR DESCRIPTION
`colcon lcov-result` will return an non-zero error code if the `coverage.info` file does not exist.
https://github.com/colcon/colcon-lcov-result/blob/master/colcon_lcov_result/verb/lcov_result.py#L128

It occurs a CI error.
https://github.com/autowarefoundation/autoware_common/runs/4945733047?check_suite_focus=true

To avoid this error, I have added a file check statement before executing the command. 

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>