### PR TITLE
fix(colcon-build-and-test): ignore errors in colcon mixin step

### DIFF
--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -48,7 +48,7 @@ runs:
 
     - name: Set up colcon-mixin
       run: |
-        colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+        colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml || true
         colcon mixin update default
       shell: bash
 


### PR DESCRIPTION
Resolves https://github.com/autowarefoundation/autoware_common/runs/4971375103?check_suite_focus=true

Since the colcon mixin repository is already set up in ros:galactic image, I removed the duplicate step. 
In other ros2 environments such as `ros-tooling/setup-ros`, the colcon mixin is not set up. Therefore, it need to be set up manually by the user.

https://hub.docker.com/layers/ros/library/ros/galactic/images/sha256-d52ee1b0d65d7df83a4897c39568d6a450a10d76c330450c90ae0e79e4c0d2a8?context=explore

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>