### PR TITLE
feat: add sync-branches action

### DIFF
--- a/sync-branches/README.md
+++ b/sync-branches/README.md
@@ -1,0 +1,54 @@
+# sync-branches
+
+## Description
+
+This action syncs branches including remote repositories.  
+It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests and [peter-evans/enable-pull-request-automerge](https://github.com/peter-evans/enable-pull-request-automerge) for enabling auto-merge.
+
+Note that you need `workflow` permission for the token if you copy workflow files of GitHub Actions.
+
+## Usage
+
+```yaml
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run sync-branches
+        uses: autowarefoundation/autoware-github-actions/sync-branches@tier4/proposal
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          base-branch: main
+          sync-target-repository: https://github.com/autowarefoundation/autoware.git
+          sync-target-branch: main
+          sync-branch: sync-upstream
+          pr-title: "chore: sync upstream"
+          auto-merge-method: merge
+```
+
+## Inputs
+
+| Name                   | Required | Description                                             |
+| ---------------------- | -------- | ------------------------------------------------------- |
+| token                  | true     | The token for pull requests.                            |
+| base-branch            | true     | The base branch of the sync PR.                         |
+| sync-pr-branch         | true     | The branch of the sync PR .                             |
+| sync-target-repository | true     | The sync target repository.                             |
+| sync-target-branch     | true     | The sync target branch.                                 |
+| pr-title               | true     | Please see `peter-evans/create-pull-request`.           |
+| pr-body                | false    | The same as above.                                      |
+| pr-labels              | false    | The same as above.                                      |
+| pr-assignees           | false    | The same as above.                                      |
+| pr-reviewers           | false    | The same as above.                                      |
+| auto-merge-method      | false    | Please see `peter-evans/enable-pull-request-automerge`. |
+
+## Outputs
+
+None.

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -1,0 +1,86 @@
+name: sync-branches
+description: ""
+
+inputs:
+  token:
+    description: ""
+    required: true
+  base-branch:
+    description: ""
+    required: true
+  sync-pr-branch:
+    description: ""
+    required: true
+  sync-target-repository:
+    description: ""
+    required: true
+  sync-target-branch:
+    description: ""
+    required: true
+  pr-title:
+    description: ""
+    required: true
+  pr-body:
+    description: ""
+    required: false
+    default: ""
+  pr-labels:
+    description: ""
+    required: false
+    default: ""
+  pr-assignees:
+    description: ""
+    required: false
+    default: ""
+  pr-reviewers:
+    description: ""
+    required: false
+    default: ""
+  auto-merge-method:
+    description: ""
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.base-branch }}
+
+    - name: Sync branches
+      run: |
+        git remote add sync-target "${{ inputs.sync-target-repository }}"
+        git fetch -pPtf --all
+        git reset --hard "sync-target/${{ inputs.sync-target-branch }}"
+      shell: bash
+
+    - name: Create PR
+      id: create-pr
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ inputs.token }}
+        base: ${{ inputs.base-branch }}
+        branch: ${{ inputs.sync-pr-branch }}
+        title: ${{ inputs.pr-title }}
+        body: ${{ inputs.pr-body }}
+        labels: ${{ inputs.pr-labels }}
+        assignees: ${{ inputs.pr-assignees }}
+        reviewers: ${{ inputs.pr-reviewers }}
+        signoff: true
+        delete-branch: true
+
+    - name: Check outputs
+      run: |
+        echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"
+      shell: bash
+
+    - name: Enable auto-merge
+      if: ${{ inputs.auto-merge-method != '' && steps.create-pr.outputs.pull-request-operation == 'created' }}
+      uses: peter-evans/enable-pull-request-automerge@v1
+      with:
+        token: ${{ inputs.token }}
+        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+        merge-method: ${{ inputs.auto-merge-method }}


### PR DESCRIPTION
Autoware Core and Universe have multiple repositories so that users can easily customize/extend Autoware.

Suppose that a company uses `autowarefoundation/autoware` and fork it to `some-company/autoware`.
In that case, it is useful if we can sync branches making `autowarefoundation/autoware` as a base.

https://github.com/wei/pull is useful for this use case, but it works only in the fork network.
Therefore, for example, it doesn't work if users manually fork repositories in multiple stages and make them private.