### PR TITLE
ci: add GitHub release workflow

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -1,0 +1,28 @@
+name: github-release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run generate-changelog
+        id: generate-changelog
+        uses: autowarefoundation/autoware-github-actions/generate-changelog@tier4/proposal
+
+      - name: Release to GitHub
+        run: |
+          echo "Release ${{ github.ref_name }}"
+          gh release create "${{ github.ref_name }}" \
+            --draft \
+            --notes "${{ steps.generate-changelog.outputs.changelog }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -25,7 +25,7 @@ body = """
     {% endfor %}
 {% endfor %}\n
 """
-# remove the leading and trailing whitespaces from the template
+# remove the leading and trailing whitespace from the template
 trim = true
 # changelog footer
 footer = """
@@ -58,4 +58,10 @@ filter_commits = false
 # glob pattern for matching git tags
 tag_pattern = "v[0-9]*"
 # regex for skipping tags
-skip_tags = "v.*-beta.*"
+skip_tags = "v0.0.0"
+# regex for ignoring tags
+ignore_tags = "v.*-beta.*"
+# sort the tags chronologically
+date_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"


### PR DESCRIPTION
It is useful if we can automatically create or prepare releases by publishing tags.

Also, since this is a repository for GitHub Actions, it's good to provide tags such as `v1`, `v2`, etc.
https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning
[Actions-R-Us/actions-tagger](https://github.com/Actions-R-Us/actions-tagger) can automate this.

I've tested this in this repository.
https://github.com/kenji-miyake/test-git-cliff-release