### PR TITLE
fix(colcon-build-and-test): fix coverage commands

### DIFF
--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -77,7 +77,7 @@ runs:
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
         colcon lcov-result --verbose --packages-above ${{ inputs.target-packages }} || true
-        colcon coveragepy-result --packages-above ${{ inputs.target-packages }} || true
+        colcon coveragepy-result --verbose --packages-above ${{ inputs.target-packages }} || true
       shell: bash
 
     - name: Cache build artifacts

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -76,12 +76,8 @@ runs:
           --mixin coverage-pytest \
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
-        if [ -n "$(find build/ -name coverage.info)" ]; then
-          colcon lcov-result --packages-above ${{ inputs.target-packages }}
-        fi
-        if [ -n "$(find build/ -name .coverage)" ]; then
-          colcon coveragepy-result --packages-above ${{ inputs.target-packages }}
-        fi
+        colcon lcov-result --packages-above ${{ inputs.target-packages }} || true
+        colcon coveragepy-result --packages-above ${{ inputs.target-packages }} || true
       shell: bash
 
     - name: Cache build artifacts

--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -71,12 +71,12 @@ runs:
     - name: Test
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
-        colcon lcov-result --initial --packages-above ${{ inputs.target-packages }}
+        colcon lcov-result --initial --verbose --packages-above ${{ inputs.target-packages }}
         colcon test --event-handlers console_cohesion+ \
           --mixin coverage-pytest \
           --packages-above ${{ inputs.target-packages }} \
           --return-code-on-test-failure
-        colcon lcov-result --packages-above ${{ inputs.target-packages }} || true
+        colcon lcov-result --verbose --packages-above ${{ inputs.target-packages }} || true
         colcon coveragepy-result --packages-above ${{ inputs.target-packages }} || true
       shell: bash
 


### PR DESCRIPTION
Changed the `colcon lcov-result` command to always be executed.
Before the change, the condition to check the existence of the `coverage.info` file was not working correctly. This is because the `colcon lcov-result` command generates the `coverage.info` file. So the if statement was always false. 
After thinking about what kind of change I would like to make, I decided to simply ignore the return value. I also applied this change to `colcon coveragepy` to account for future API changes.

I will check this change in my forked repository. After confirming this change, I will post the result and change the state to ready for review.

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>