### PR TITLE
feat: add set-git-config action

### DIFF
--- a/set-git-config/README.md
+++ b/set-git-config/README.md
@@ -1,0 +1,39 @@
+# set-git-config
+
+## Description
+
+This action sets several git configs.
+
+- `url.<base>.insteadOf`
+- `user.name`
+- `user.email`
+
+## Usage
+
+```yaml
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@tier4/proposal
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+```
+
+## Inputs
+
+| Name  | Required | Description                           |
+| ----- | -------- | ------------------------------------- |
+| token | true     | The token for `url.<base>.insteadOf`. |
+
+## Outputs
+
+None.

--- a/set-git-config/action.yaml
+++ b/set-git-config/action.yaml
@@ -1,0 +1,19 @@
+name: set-git-config
+description: ""
+
+inputs:
+  token:
+    description: ""
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set git config
+      run: |
+        git config --local --unset-all http.https://github.com/.extraheader || true
+        git config --global --add url.https://x-access-token:${{ inputs.token }}@github.com/.insteadOf 'https://github.com/'
+        git config --global --add url.https://x-access-token:${{ inputs.token }}@github.com/.insteadOf 'git@github.com:'
+        git config --global user.name github-actions
+        git config --global user.email github-actions@github.com
+      shell: bash


### PR DESCRIPTION
In #43, I split the step of `git config` into a composite action to reduce repetitions.