### PR TITLE
chore: sync community health files

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -1,5 +1,9 @@
 - repository: autowarefoundation/autoware
   files:
+    - source: CODE_OF_CONDUCT.md
+    - source: CONTRIBUTING.md
+    - source: DISCLAIMER.md
+    - source: LICENSE
     - source: .github/dependabot.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/spell-check.yaml


### PR DESCRIPTION
After https://github.com/autowarefoundation/autoware/pull/29 is merged, we have to copy the files to this repository.