### PR TITLE
fix(colcon-build-and-test): change cache path

### DIFF
--- a/colcon-build-and-test/action.yaml
+++ b/colcon-build-and-test/action.yaml
@@ -90,6 +90,4 @@ runs:
         path: |
           ./build
           ./install
-          ./lcov
-          ./coveragepy
         key: build-${{ github.sha }}


### PR DESCRIPTION
Closes #47 

I have confirmed that this PR fixes the problem:
https://github.com/KeisukeShima/autoware.universe/runs/5048312036?check_suite_focus=true
![image](https://user-images.githubusercontent.com/19993104/152302722-bef168d8-8f6b-46d9-9de7-7f2a9dd53da2.png)

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>