### PR TITLE
ci: add actions-tagger.yaml

### DIFF
--- a/.github/workflows/actions-tagger.yaml
+++ b/.github/workflows/actions-tagger.yaml
@@ -1,0 +1,13 @@
+name: actions-tagger
+
+on:
+  release:
+    types:
+      - published
+      - edited
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@v2


### PR DESCRIPTION
As explained in https://github.com/autowarefoundation/autoware-github-actions/pull/38#issue-1118683293, I'll add [Actions-R-Us/actions-tagger](https://github.com/Actions-R-Us/actions-tagger).