### PR TITLE
fix(generate-changelog): remove CHANGELOG.md

### DIFF
--- a/generate-changelog/action.yaml
+++ b/generate-changelog/action.yaml
@@ -44,6 +44,7 @@ runs:
           -vv --strip header ${{ inputs.git-cliff-args }}
 
         r=$(cat CHANGELOG.md)
+        rm CHANGELOG.md
 
         # Trim version and date
         if [ "${{ inputs.trim-version-and-date }}" = "true" ]; then

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -61,7 +61,7 @@ runs:
       id: generate-changelog
       uses: autowarefoundation/autoware-github-actions/generate-changelog@tier4/proposal
       with:
-        git-cliff-args: "origin/${{ inputs.base-branch }}..HEAD"
+        git-cliff-args: origin/${{ inputs.base-branch }}..HEAD
 
     - name: Create PR
       id: create-pr


### PR DESCRIPTION
Remove `CHANGELOG.md` in `generate-changelog` to prevent unintended commits.

https://github.com/kenji-miyake/autoware-github-actions/pull/16/commits/b84f77ec8930bca61ea9b72f66ffdfdbba1ac9d6