### PR TITLE
fix: get-modified-packages.sh

### DIFF
--- a/get-modified-packages/get-modified-packages.sh
+++ b/get-modified-packages/get-modified-packages.sh
@@ -64,4 +64,4 @@ done
 #
 # Output
 # shellcheck disable=SC2046
-echo ::set-output name=modified-packages::$(printf "%s\n" "${modified_package_names[@]}" | sort -u )
+echo ::set-output name=modified-packages::$(printf "%s\n" "${modified_package_names[@]}" | sort -u)


### PR DESCRIPTION
In previous implementation, `get-modified-packages.sh` can't get moified packages from the following structure of repository.
```
exapmple_launch$ tree 
.
├── CMakeLists.txt
├── launch
├── package.xml
├── README.md
...
```
This PR fixes this problem.