### PR TITLE
fix(spell-check): ignore dist/

### DIFF
--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -24,4 +24,7 @@ runs:
       with:
         config: .cspell.json
         files: |
+          **
+          .*
+          .*/**
           !dist/**/*.{ts,js}

--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -20,7 +20,7 @@ runs:
       shell: bash
 
     - name: Run spell check
-      uses: streetsidesoftware/cspell-action@v1.3.5
+      uses: streetsidesoftware/cspell-action@v1
       with:
         config: .cspell.json
         files: |

--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -23,3 +23,5 @@ runs:
       uses: streetsidesoftware/cspell-action@v1.3.5
       with:
         config: .cspell.json
+        files: |
+          !dist/**/*.{ts,js}


### PR DESCRIPTION
`dist/` is commonly used as the auto-generated files of JavaScript/TypeScript actions.
https://github.com/streetsidesoftware/cspell-action#usage