### PR TITLE
revert(spell-check): ignore dist/

### DIFF
--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -20,11 +20,6 @@ runs:
       shell: bash
 
     - name: Run spell check
-      uses: streetsidesoftware/cspell-action@v1
+      uses: streetsidesoftware/cspell-action@v1.3.5
       with:
         config: .cspell.json
-        files: |
-          **
-          .*
-          .*/**
-          !dist/**/*.{ts,js}

--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -20,6 +20,6 @@ runs:
       shell: bash
 
     - name: Run spell check
-      uses: streetsidesoftware/cspell-action@v1.3.5
+      uses: streetsidesoftware/cspell-action@v1
       with:
         config: .cspell.json


### PR DESCRIPTION
Reverts autowarefoundation/autoware-github-actions#70

Ignored in https://github.com/tier4/autoware-spell-check-dict/pull/207.