### PR TITLE
feat(clang-tidy): export files for clang-tidy-pr-comments

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -95,7 +95,7 @@ runs:
       run: |
         package_path=$(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
         target_files=$(find $package_path -name "*.cpp" -or -name "*.hpp")
-        echo ::set-output name=target-files::"$target_files"
+        echo ::set-output name=target-files::$target_files
       shell: bash
 
     - name: Analyze

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -106,6 +106,7 @@ runs:
       shell: bash
 
     - name: Save PR metadata
+      if: ${{ steps.get-target-files.outputs.target-files != '' }}
       run: |
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
@@ -113,6 +114,7 @@ runs:
       shell: bash
 
     - uses: actions/upload-artifact@v2
+      if: ${{ steps.get-target-files.outputs.target-files != '' }}
       with:
         name: clang-tidy-result
         path: /tmp/clang-tidy-result/

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -101,5 +101,18 @@ runs:
     - name: Analyze
       if: ${{ steps.get-target-files.outputs.target-files != '' }}
       run: |
-        clang-tidy -p build/ ${{ steps.get-target-files.outputs.target-files }}
+        mkdir /tmp/clang-tidy-result
+        clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml ${{ steps.get-target-files.outputs.target-files }} || true
       shell: bash
+
+    - name: Save PR metadata
+      run: |
+        echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
+        echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
+        echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt
+      shell: bash
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: clang-tidy-result
+        path: /tmp/clang-tidy-result/


### PR DESCRIPTION
https://github.com/platisd/clang-tidy-pr-comments

- Useful features
- Simple interface of `fixes.yaml`

Alternative apps:
- https://github.com/ZedThree/clang-tidy-review
  - Probably no interface for `fixes.yaml`