### PR TITLE
fix(colcon-build,colcon-test): match build and test cache

### DIFF
--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -66,16 +66,10 @@ runs:
           --mixin coverage-gcc coverage-pytest compile-commands
       shell: bash
 
-    - name: Determine CPU architecture
-      id: determine-architecture
-      run: |
-        echo ::set-output name=arch::$(uname -m)
-      shell: bash
-
     - name: Cache build artifacts
       uses: actions/cache@v2
       with:
         path: |
           ./build
           ./install
-        key: build-${{ runner.os }}-${{ steps.determine-architecture.outputs.arch }}-${{ github.sha }}
+        key: build-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -66,10 +66,16 @@ runs:
           --mixin coverage-gcc coverage-pytest compile-commands
       shell: bash
 
+    - name: Determine CPU architecture
+      id: determine-architecture
+      run: |
+        echo ::set-output name=arch::$(uname -m)
+      shell: bash
+
     - name: Cache build artifacts
       uses: actions/cache@v2
       with:
         path: |
           ./build
           ./install
-        key: build-${{ github.sha }}
+        key: build-${{ runner.os }}-${{ steps.determine-architecture.outputs.arch }}-${{ github.sha }}

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -66,6 +66,12 @@ runs:
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 
+    - name: Determine CPU architecture
+      id: determine-architecture
+      run: |
+        echo ::set-output name=arch::$(uname -m)
+      shell: bash
+
     - name: Restore build files from cache
       id: restore-build-files
       uses: actions/cache@v2
@@ -73,7 +79,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ github.sha }}
+        key: build-${{ runner.os }}-${{ steps.determine-architecture.outputs.arch }}-${{ github.sha }}
 
     - name: Test
       run: |

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -66,12 +66,6 @@ runs:
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 
-    - name: Determine CPU architecture
-      id: determine-architecture
-      run: |
-        echo ::set-output name=arch::$(uname -m)
-      shell: bash
-
     - name: Restore build files from cache
       id: restore-build-files
       uses: actions/cache@v2
@@ -79,7 +73,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ runner.os }}-${{ steps.determine-architecture.outputs.arch }}-${{ github.sha }}
+        key: build-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
 
     - name: Test
       run: |


### PR DESCRIPTION
Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>

Resolves: https://github.com/autowarefoundation/autoware.universe/issues/403

This is a change to match the `colcon-build` and `colcon-test` caches to account for OS and CPU architecture.