### PR TITLE
chore(cliff.toml): fix tag_pattern

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -57,7 +57,7 @@ commit_parsers = [
 # filter out the commits that are not matched by commit parsers
 filter_commits = false
 # glob pattern for matching git tags
-tag_pattern = "v[0-9]*"
+tag_pattern = "v[0-9]*.[0-9]*.[0-9]*"
 # regex for skipping tags
 skip_tags = "v0.0.0"
 # regex for ignoring tags


### PR DESCRIPTION
To ignore tags like `v0`, `v1`, etc.