### PR TITLE
test: fix URL of .clang-tidy

### DIFF
--- a/.github/workflows/test-composite-actions.yaml
+++ b/.github/workflows/test-composite-actions.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: empty_target
-          clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/tier4/proposal/.clang-tidy
+          clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
 
   test-check-file-existence:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A follow-up for #85 and #86.