### PR TITLE
fix(deploy-docs): add `--update-aliases` and `--no-redirect` to `mike alias`

### DIFF
--- a/deploy-docs/action.yaml
+++ b/deploy-docs/action.yaml
@@ -63,7 +63,7 @@ runs:
     - name: Create alias 'latest'
       if: ${{ inputs.latest == 'true' }}
       run: |
-        mike alias --push --rebase ${{ steps.set-docs-version-name.outputs.version-name }} latest
+        mike alias --push --rebase --update-aliases --no-redirect ${{ steps.set-docs-version-name.outputs.version-name }} latest
       shell: bash
 
     - name: Create comment body


### PR DESCRIPTION
As a follow-up to #93, added options.

https://github.com/jimporter/mike#building-your-docs

> If [version] already exists, this command will also update all of the pre-existing aliases for it. Normally, if an alias specified on the command line is already associated with another version, this will return an error. If you do want to move an alias from another version to this version (e.g. when releasing a new version and updating the latest alias to point to this new version), you can pass -u/--update-aliases to allow this.
> 
> By default, aliases create a simple HTML redirect to the real version of the docs; to create a copy of the docs for each alias, you can pass --no-redirect. 