### PR TITLE
fix(delete-closed-pr-docs): ignore latest tag on pull_request

### DIFF
--- a/delete-closed-pr-docs/action.yaml
+++ b/delete-closed-pr-docs/action.yaml
@@ -39,7 +39,7 @@ runs:
 
         closed_docs_versions=()
         for docs_version in ${{ steps.get-docs-versions.outputs.docs-versions }}; do
-          pr_number=$(echo "$docs_version" | grep -oP "pr-\K([0-9]+)")
+          pr_number=$(echo "$docs_version" | grep -oP "pr-\w+")
           url="https://api.github.com/repos/${{ github.repository }}/pulls/$pr_number"
 
           echo "url: $url"

--- a/delete-closed-pr-docs/action.yaml
+++ b/delete-closed-pr-docs/action.yaml
@@ -29,7 +29,7 @@ runs:
       id: get-docs-versions
       run: |
         echo "site_name: dummy" > mkdocs.yaml
-        echo ::set-output name=docs-versions::$(mike list | grep "pr-")
+        echo ::set-output name=docs-versions::$(mike list | grep -oP "pr-\w+")
       shell: bash
 
     - name: Find closed docs versions
@@ -39,7 +39,7 @@ runs:
 
         closed_docs_versions=()
         for docs_version in ${{ steps.get-docs-versions.outputs.docs-versions }}; do
-          pr_number=$(echo "$docs_version" | grep -oP "pr-\w+")
+          pr_number=$(echo "$docs_version" | grep -oP "pr-\K([0-9]+")
           url="https://api.github.com/repos/${{ github.repository }}/pulls/$pr_number"
 
           echo "url: $url"

--- a/delete-closed-pr-docs/action.yaml
+++ b/delete-closed-pr-docs/action.yaml
@@ -39,7 +39,7 @@ runs:
 
         closed_docs_versions=()
         for docs_version in ${{ steps.get-docs-versions.outputs.docs-versions }}; do
-          pr_number=$(echo "$docs_version" | grep -oP "pr-\K([0-9]+")
+          pr_number=$(echo "$docs_version" | grep -oP "pr-\K([0-9]+)")
           url="https://api.github.com/repos/${{ github.repository }}/pulls/$pr_number"
 
           echo "url: $url"


### PR DESCRIPTION
Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>

## Description

<!-- Write a brief description of this PR. -->
Related #96
The problem is that `delete-closed-pr-docs` cannot ignore `latest` tag.
To resolve this, I have modified the script to https://github.com/autowarefoundation/autoware-github-actions/issues/96#issuecomment-1061292507

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
