### PR TITLE
ci: add dependabot for composite actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,99 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /check-file-existence
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /clang-tidy
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /colcon-build
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /colcon-test
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /delete-closed-pr-docs
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /deploy-docs
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /generate-changelog
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /get-modified-packages
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /get-self-packages
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /pre-commit
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /register-autonomoustuff-repository
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /remove-exec-depend
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /set-git-config
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /spell-check
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /sync-branches
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /sync-files
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Added `dependabot` settings for composite actions.

![image](https://user-images.githubusercontent.com/31987104/159238859-1db09537-6ca7-482a-b8df-9e4ab99f6e82.png)

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
