### PR TITLE
fix(delete-closed-pr-docs): remove PR directory when there is no corresponding PR

### DIFF
--- a/delete-closed-pr-docs/action.yaml
+++ b/delete-closed-pr-docs/action.yaml
@@ -43,9 +43,11 @@ runs:
           url="https://api.github.com/repos/${{ github.repository }}/pulls/$pr_number"
 
           echo "url: $url"
-          state=$(curl -fsSL "$url" -H "Authorization: token ${{ inputs.token }}" | grep -oP '"state": "\K([a-z]+)')
+          response=$(curl -sSL "$url" -H "Authorization: token ${{ inputs.token }}")
+          message=$(echo "$response" | grep -oP '"message": "\K([^"]+)')
+          state=$(echo "$response" | grep -oP '"state": "\K([a-z]+)')
 
-          if [ "$state" = "closed" ]; then
+          if [ "$message" = "Not Found" ] || [ "$state" = "closed" ]; then
             closed_docs_versions+=("$docs_version")
           fi
         done


### PR DESCRIPTION
Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>

## Description

<!-- Write a brief description of this PR. -->
Closes #79 
(The description is in issue.)

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
