### PR TITLE
fix(delete-closed-pr-docs): ignore errors

### DIFF
--- a/delete-closed-pr-docs/action.yaml
+++ b/delete-closed-pr-docs/action.yaml
@@ -44,8 +44,8 @@ runs:
 
           echo "url: $url"
           response=$(curl -sSL "$url" -H "Authorization: token ${{ inputs.token }}")
-          message=$(echo "$response" | grep -oP '"message": "\K([^"]+)')
-          state=$(echo "$response" | grep -oP '"state": "\K([a-z]+)')
+          message=$(echo "$response" | grep -oP '"message": "\K([^"]+)') || true
+          state=$(echo "$response" | grep -oP '"state": "\K([a-z]+)') || true
 
           if [ "$message" = "Not Found" ] || [ "$state" = "closed" ]; then
             closed_docs_versions+=("$docs_version")


### PR DESCRIPTION
Closes #79 
Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>

## Description

<!-- Write a brief description of this PR. -->
Follow-up PR for #79 

I have tested this change on my fork repo:
https://github.com/KeisukeShima/autoware.universe/runs/5638647412?check_suite_focus=true

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
