### PR TITLE
feat(deploy-docs): don't use mike alias for latest

### DIFF
--- a/deploy-docs/action.yaml
+++ b/deploy-docs/action.yaml
@@ -63,7 +63,7 @@ runs:
     - name: Create alias 'latest'
       if: ${{ inputs.latest == 'true' }}
       run: |
-        mike alias --push --rebase --update-aliases --no-redirect ${{ steps.set-docs-version-name.outputs.version-name }} latest
+        mike alias --push --rebase latest
       shell: bash
 
     - name: Create comment body


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It seems `mike alias` doesn't alias images, which is inconvenient for us.

So I changed it to copy all files.
It will increase the file size, but I assume it's not a big problem.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
