### PR TITLE
feat(sync-files): enable auto merge

### DIFF
--- a/sync-files/README.md
+++ b/sync-files/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 This action syncs files between repositories.  
-It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests.
+It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests and [peter-evans/enable-pull-request-automerge](https://github.com/peter-evans/enable-pull-request-automerge) for enabling auto-merge.
 
 Note that you need `workflow` permission for the token if you copy workflow files of GitHub Actions.
 
@@ -25,6 +25,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/sync-files@v1
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          auto-merge-method: squash
 ```
 
 Create `.github/sync-files.yaml` like this.
@@ -63,17 +64,18 @@ The specifications are:
 
 ## Inputs
 
-| Name              | Required | Description                                 |
-| ----------------- | -------- | ------------------------------------------- |
-| token             | true     | The token for pull requests.                |
-| config            | false    | The path to `sync-files.yaml`.              |
-| pr-base           | false    | Refer to `peter-evans/create-pull-request`. |
-| pr-branch         | false    | The same as above.                          |
-| pr-title          | false    | The same as above.                          |
-| pr-commit-message | false    | The same as above.                          |
-| pr-labels         | false    | The same as above.                          |
-| pr-assignees      | false    | The same as above.                          |
-| pr-reviewers      | false    | The same as above.                          |
+| Name              | Required | Description                                           |
+| ----------------- | -------- | ----------------------------------------------------- |
+| token             | true     | The token for pull requests.                          |
+| config            | false    | The path to `sync-files.yaml`.                        |
+| pr-base           | false    | Refer to `peter-evans/create-pull-request`.           |
+| pr-branch         | false    | The same as above.                                    |
+| pr-title          | false    | The same as above.                                    |
+| pr-commit-message | false    | The same as above.                                    |
+| pr-labels         | false    | The same as above.                                    |
+| pr-assignees      | false    | The same as above.                                    |
+| pr-reviewers      | false    | The same as above.                                    |
+| auto-merge-method | false    | Refer to `peter-evans/enable-pull-request-automerge`. |
 
 ## Outputs
 

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -37,6 +37,11 @@ inputs:
     description: ""
     required: false
     default: ""
+  auto-merge-method:
+    description: ""
+    required: false
+    default: ""
+
 
 runs:
   using: composite
@@ -185,3 +190,11 @@ runs:
         echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
         echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"
       shell: bash
+
+    - name: Enable auto-merge
+      if: ${{ inputs.auto-merge-method != '' && steps.create-pr.outputs.pull-request-operation == 'created' }}
+      uses: peter-evans/enable-pull-request-automerge@v2
+      with:
+        token: ${{ inputs.token }}
+        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+        merge-method: ${{ inputs.auto-merge-method }}

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -42,7 +42,6 @@ inputs:
     required: false
     default: ""
 
-
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Signed-off-by: h-ohta <hiroki.ota@tier4.jp>

## Description

- Add `Enable auto merge` as a reference 
  https://github.com/autowarefoundation/autoware-github-actions/blob/main/sync-branches/action.yaml#L102-L108
- Actually, we also have to set `auto-merge-method` variables` to any in order to enable auto merge.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
