### PR TITLE
feat(get-modified-packages): make base-branch an input in order to be testable

### DIFF
--- a/.github/workflows/test-composite-actions.yaml
+++ b/.github/workflows/test-composite-actions.yaml
@@ -182,6 +182,8 @@ jobs:
       - name: Run get-modified-packages
         id: get-modified-packages
         uses: ./get-modified-packages
+        with:
+          base-branch: ${{ github.event.repository.default_branch }}
 
       - name: Check result of get-modified-packages
         run: |

--- a/get-modified-packages/README.md
+++ b/get-modified-packages/README.md
@@ -21,7 +21,9 @@ jobs:
 
 ## Inputs
 
-None.
+| Name        | Required | Description                                      |
+| ----------- | -------- | ------------------------------------------------ |
+| base-branch | false    | The base branch to search for modified packages. |
 
 ## Outputs
 

--- a/get-modified-packages/action.yaml
+++ b/get-modified-packages/action.yaml
@@ -1,6 +1,12 @@
 name: get-modified-packages
 description: ""
 
+inputs:
+  base-branch:
+    description: ""
+    required: false
+    default: ${{ github.base_ref }}
+
 outputs:
   modified-packages:
     description: ""
@@ -17,7 +23,7 @@ runs:
     - name: Get modified packages
       id: get-modified-packages
       run: |
-        ${GITHUB_ACTION_PATH}/get-modified-packages.sh origin/${{ github.base_ref }}
+        ${GITHUB_ACTION_PATH}/get-modified-packages.sh origin/${{ inputs.base-branch }}
       shell: bash
 
     - name: Show result


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`github.base_ref` is only accessible from `pull_request` events.
https://docs.github.com/en/actions/learn-github-actions/contexts

Therefore, it can't be tested now.
https://github.com/autowarefoundation/autoware-github-actions/runs/6070315459?check_suite_focus=true#step:10:9

To resolve this, I made the `base-branch` an input.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
