### PR TITLE
ci(test-composite-actions): relpace default_branch with main

### DIFF
--- a/.github/workflows/test-composite-actions.yaml
+++ b/.github/workflows/test-composite-actions.yaml
@@ -183,7 +183,7 @@ jobs:
         id: get-modified-packages
         uses: ./get-modified-packages
         with:
-          base-branch: ${{ github.event.repository.default_branch }}
+          base-branch: main
 
       - name: Check result of get-modified-packages
         run: |


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It seems can't be used in scheduled jobs. :thinking: 

https://github.com/autowarefoundation/autoware-github-actions/runs/6185500582?check_suite_focus=true#step:10:3

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
