### PR TITLE
fix(deploy-docs): remove mdx_unimoji

### DIFF
--- a/deploy-docs/mkdocs-requirements.txt
+++ b/deploy-docs/mkdocs-requirements.txt
@@ -1,7 +1,6 @@
 fontawesome_markdown
 markdown
 mdx_truly_sane_lists
-mdx_unimoji
 mkdocs
 mkdocs-awesome-pages-plugin
 mkdocs-exclude


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
mdx_unimoji is deprecated and it should be deleted
https://github.com/autowarefoundation/autoware-github-actions/issues/145

If you use emoji, you can use https://github.com/facelessuser/pymdown-extensions for example, which is automatically installed with deploy-docs/mkdocs-requirements.txt

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
