### PR TITLE
feat(semantic-pull-request): disable validateSingleCommitMatchesPrTitle

### DIFF
--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -30,7 +30,6 @@ jobs:
             revert
           subjectPattern: ^(?![A-Z]).+$
           validateSingleCommit: true
-          validateSingleCommitMatchesPrTitle: true
           ignoreLabels: |
             bot
             ignore-semantic-pull-request


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

An alternative feature is officially supported.

https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/
https://github.com/github/feedback/discussions/16271

However, I think we have to instead check if the option is enabled.
So I'll make this a draft until that.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
