### PR TITLE
feat(sync-files): add pre-command and post-command

### DIFF
--- a/sync-files/README.md
+++ b/sync-files/README.md
@@ -67,7 +67,7 @@ The specifications are:
 In the `pre-command` and `post-command` options, the following special variables can be used:
 
 - `{source}`: The sync source file
-- `{target}`: The sync target file
+- `{dest}`: The sync dest file
 
 ## Inputs
 

--- a/sync-files/README.md
+++ b/sync-files/README.md
@@ -61,13 +61,23 @@ The specifications are:
 | files/dest            | false    | The same as `files/source`.                  | The path where to place the synced file in the base repository.                          |
 | files/replace         | false    | `true`                                       | Whether to replace the synced file if it already exists.                                 |
 | files/delete-orphaned | false    | `true`                                       | Whether to delete the synced file if it does not exist in the target repository anymore. |
-| files/pre-command     | false    | `""`                                         | The command executed before copying the file.                                            |
-| files/post-command    | false    | `""`                                         | The command executed after copying the file.                                             |
+| files/pre-commands    | false    | `""`                                         | The multi-line commands executed before copying the file.                                |
+| files/post-commands   | false    | `""`                                         | The multi-line commands executed after copying the file.                                 |
 
-In the `pre-command` and `post-command` options, the following special variables can be used:
+In the `pre-commands` and `post-commands` options, the following special variables can be used:
 
 - `{source}`: The sync source file
 - `{dest}`: The sync dest file
+
+Example:
+
+```yaml
+- repository: autowarefoundation/autoware
+  files:
+    - source: .pre-commit-config.yaml
+      post-commands: |
+        sd -f ms "[^\n]*shellcheck-py\n.*?\n\n" "" {dest}
+```
 
 ## Inputs
 

--- a/sync-files/README.md
+++ b/sync-files/README.md
@@ -61,6 +61,13 @@ The specifications are:
 | files/dest            | false    | The same as `files/source`.                  | The path where to place the synced file in the base repository.                          |
 | files/replace         | false    | `true`                                       | Whether to replace the synced file if it already exists.                                 |
 | files/delete-orphaned | false    | `true`                                       | Whether to delete the synced file if it does not exist in the target repository anymore. |
+| files/pre-command     | false    | `""`                                         | The command executed before copying the file.                                            |
+| files/post-command    | false    | `""`                                         | The command executed after copying the file.                                             |
+
+In the `pre-command` and `post-command` options, the following special variables can be used:
+
+- `{source}`: The sync source file
+- `{target}`: The sync target file
 
 ## Inputs
 

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -61,6 +61,9 @@ runs:
       with:
         yq-version: v4.25.1
 
+    - name: Set up sd
+      uses: kenji-miyake/setup-sd@v1
+
     - name: Parse config
       run: |
         pip3 install pyyaml

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -98,15 +98,15 @@ runs:
             dest_path=$(yq ".dest" /tmp/file-config.yaml)
             replace=$(yq ".replace" /tmp/file-config.yaml)
             delete_orphaned=$(yq ".delete-orphaned" /tmp/file-config.yaml)
-            pre_command=$(yq ".pre-command" /tmp/file-config.yaml)
-            post_command=$(yq ".post-command" /tmp/file-config.yaml)
+            pre_commands=$(yq ".pre-commands" /tmp/file-config.yaml)
+            post_commands=$(yq ".post-commands" /tmp/file-config.yaml)
 
             modified_source_path="/tmp/repository/$source_path"
 
-            pre_command=$(echo "$pre_command" | sed "s|{source}|$modified_source_path|g" | sed "s|{dest}|$dest_path|g")
-            post_command=$(echo "$post_command" | sed "s|{source}|$modified_source_path|g" | sed "s|{dest}|$dest_path|g")
-            [ -n "$pre_command" ] && echo "pre_command for $source_path: $pre_command"
-            [ -n "$post_command" ] && echo "post_command for $source_path: $post_command"
+            pre_commands=$(echo "$pre_commands" | sed "s|{source}|$modified_source_path|g" | sed "s|{dest}|$dest_path|g")
+            post_commands=$(echo "$post_commands" | sed "s|{source}|$modified_source_path|g" | sed "s|{dest}|$dest_path|g")
+            [ -n "$pre_commands" ] && echo "pre_commands for $source_path: $pre_commands"
+            [ -n "$post_commands" ] && echo "post_commands for $source_path: $post_commands"
 
             if [ -f "$modified_source_path" ]; then
               if [ -f "$dest_path" ] && [ "$replace" != "true" ]; then
@@ -119,17 +119,17 @@ runs:
                 echo "Newly copy $source_path to $dest_path."
                 mkdir -p $(dirname "$dest_path")
 
-                eval "$pre_command" || true
+                eval "$pre_commands" || true
                 cp "$modified_source_path" "$dest_path"
-                eval "$post_command"
+                eval "$post_commands"
 
                 yq -i ".added += [\"$dest_path\"]" /tmp/result.yaml
               elif ! diff "$modified_source_path" "$dest_path"; then
                 echo "Copy $source_path to $dest_path."
 
-                eval "$pre_command"
+                eval "$pre_commands"
                 cp "$modified_source_path" "$dest_path"
-                eval "$post_command"
+                eval "$post_commands"
 
                 yq -i ".changed += [\"$dest_path\"]" /tmp/result.yaml
               else

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -95,9 +95,17 @@ runs:
             dest_path=$(yq ".dest" /tmp/file-config.yaml)
             replace=$(yq ".replace" /tmp/file-config.yaml)
             delete_orphaned=$(yq ".delete-orphaned" /tmp/file-config.yaml)
+            pre_command=$(yq ".pre-command" /tmp/file-config.yaml)
+            post_command=$(yq ".post-command" /tmp/file-config.yaml)
 
-            source_file="/tmp/repository/$source_path"
-            if [ -f "$source_file" ]; then
+            modified_source_path="/tmp/repository/$source_path"
+
+            pre_command=$(echo "$pre_command" | sed "s|{source}|$modified_source_path|g" | sed "s|{dest}|$dest_path|g")
+            post_command=$(echo "$post_command" | sed "s|{source}|$modified_source_path|g" | sed "s|{dest}|$dest_path|g")
+            [ -n "$pre_command" ] && echo "pre_command for $source_path: $pre_command"
+            [ -n "$post_command" ] && echo "post_command for $source_path: $post_command"
+
+            if [ -f "$modified_source_path" ]; then
               if [ -f "$dest_path" ] && [ "$replace" != "true" ]; then
                 echo "Skip copying to $dest_path."
                 yq -i ".skipped += [\"$dest_path\"]" /tmp/result.yaml
@@ -107,11 +115,19 @@ runs:
               if ! [ -f "$dest_path" ]; then
                 echo "Newly copy $source_path to $dest_path."
                 mkdir -p $(dirname "$dest_path")
-                cp "$source_file" "$dest_path"
+
+                eval "$pre_command" || true
+                cp "$modified_source_path" "$dest_path"
+                eval "$post_command"
+
                 yq -i ".added += [\"$dest_path\"]" /tmp/result.yaml
-              elif ! diff "$source_file" "$dest_path"; then
+              elif ! diff "$modified_source_path" "$dest_path"; then
                 echo "Copy $source_path to $dest_path."
-                cp "$source_file" "$dest_path"
+
+                eval "$pre_command"
+                cp "$modified_source_path" "$dest_path"
+                eval "$post_command"
+
                 yq -i ".changed += [\"$dest_path\"]" /tmp/result.yaml
               else
                 echo "$source_path and $dest_path are the same."

--- a/sync-files/parse_config.py
+++ b/sync-files/parse_config.py
@@ -36,11 +36,11 @@ def main():
             if "delete-orphaned" not in item:
                 item["delete-orphaned"] = True
 
-            if "pre-command" not in item:
-                item["pre-command"] = ""
+            if "pre-commands" not in item:
+                item["pre-commands"] = ""
 
-            if "post-command" not in item:
-                item["post-command"] = ""
+            if "post-commands" not in item:
+                item["post-commands"] = ""
 
     print(yaml.dump(config))
 

--- a/sync-files/parse_config.py
+++ b/sync-files/parse_config.py
@@ -36,6 +36,12 @@ def main():
             if "delete-orphaned" not in item:
                 item["delete-orphaned"] = True
 
+            if "pre-command" not in item:
+                item["pre-command"] = ""
+
+            if "post-command" not in item:
+                item["post-command"] = ""
+
     print(yaml.dump(config))
 
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It's useful if we can run commands before/after copying files.
https://github.com/chmln/sd is added because it's more useful than pure `sed`.

I've tested this in https://github.com/kenji-miyake/autoware-github-actions/pull/43.
The CI log is https://github.com/kenji-miyake/autoware-github-actions/runs/6427565108?check_suite_focus=true.

Sample settings:

```yaml
- repository: autowarefoundation/autoware
  files:
    - source: .pre-commit-config.yaml
      post-commands: |
        sd -f ms "[^\n]*shellcheck-py\n.*?\n\n" "" {dest}
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
