### PR TITLE
feat: remove_exec_depend without self packages

### DIFF
--- a/remove-exec-depend/action.yaml
+++ b/remove-exec-depend/action.yaml
@@ -4,7 +4,6 @@ description: ""
 runs:
   using: composite
   steps:
-
     - name: Check out default_branch
       uses: actions/checkout@v3
       with:

--- a/remove-exec-depend/action.yaml
+++ b/remove-exec-depend/action.yaml
@@ -4,7 +4,26 @@ description: ""
 runs:
   using: composite
   steps:
+
+    - name: Check out default_branch
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        fetch-depth: 0
+
+    - name: Get self packages
+      id: get-self-packages
+      uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
+
+    - name: Check out head branch
+      if: ${{ github.head_ref != '' }}
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+
     - name: Remove exec_depend
       run: |
-        find . -name package.xml | xargs -I {} sed -i -rz "s|<exec_depend>\s*[a-zA-Z_0-9]+\s*</exec_depend>\n||g" {}
+        find . -name package.xml | xargs -I {} python3 ${GITHUB_ACTION_PATH}/remove_exec_depend.py --package_xml {} --exclude_packages ${{ steps.get-self-packages.outputs.self-packages }}
+        find . -name package.xml | xargs cat
       shell: bash

--- a/remove-exec-depend/action.yaml
+++ b/remove-exec-depend/action.yaml
@@ -23,6 +23,6 @@ runs:
 
     - name: Remove exec_depend
       run: |
-        find . -name package.xml | xargs -I {} python3 ${GITHUB_ACTION_PATH}/remove_exec_depend.py --package_xml {} --exclude_packages ${{ steps.get-self-packages.outputs.self-packages }}
+        find . -name package.xml | xargs -I {} python3 ${GITHUB_ACTION_PATH}/remove_exec_depend.py --package-xml {} --exclude-packages ${{ steps.get-self-packages.outputs.self-packages }}
         find . -name package.xml | xargs cat
       shell: bash

--- a/remove-exec-depend/remove_exec_depend.py
+++ b/remove-exec-depend/remove_exec_depend.py
@@ -1,0 +1,30 @@
+import argparse
+import re
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--package_xml", required=True)
+    parser.add_argument("--exclude_packages", required=False, nargs="*", type=str)
+    args = parser.parse_args()
+
+    exclude_packages = args.exclude_packages if args.exclude_packages is not None else []
+    data_lines = None
+    with Path(args.package_xml).open(mode='r') as f:
+        data_lines = f.readlines()
+
+    with Path(args.package_xml).open('w') as f:
+        for line in data_lines:
+            # write without exec depend
+            if re.match(r'\s*<exec_depend>\s*[a-zA-Z_0-9\-]+\s*</exec_depend>\n', line) is None:
+                f.write(line)
+            else:
+                # evaluate exclude packages
+                for ex in exclude_packages:
+                    if ex in line:
+                        f.write(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/remove-exec-depend/remove_exec_depend.py
+++ b/remove-exec-depend/remove_exec_depend.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--package_xml", required=True)
-    parser.add_argument("--exclude_packages", required=False, nargs="*", type=str)
+    parser.add_argument("--package-xml", required=True)
+    parser.add_argument("--exclude-packages", required=False, nargs="*", type=str)
     args = parser.parse_args()
 
     exclude_packages = args.exclude_packages if args.exclude_packages is not None else []


### PR DESCRIPTION
## Description

- execute `remove_exec_depend` without self packages.
- This is tested at https://github.com/tier4/autoware_launch/pull/317 and [build-and-test-differential](https://github.com/tier4/autoware_launch/runs/6506250931?check_suite_focus=true) and [build-and-test](https://github.com/tier4/autoware_launch/runs/6506286406?check_suite_focus=true)
- for checking package.xml, debug code is added
  https://github.com/autowarefoundation/autoware-github-actions/blob/5618759483847c575cf60abf98d653e12fb4ddf0/remove-exec-depend/action.yaml#L28

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
