### PR TITLE
fix(sync-branches): remove git remote "sync-target" after using the data

### DIFF
--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -56,6 +56,7 @@ runs:
         git remote add sync-target "${{ inputs.sync-target-repository }}"
         git fetch -pPtf --all
         git reset --hard "sync-target/${{ inputs.sync-target-branch }}"
+        git remote rm sync-target
       shell: bash
 
     - name: Generate changelog


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It causes an error when there is a branch named samely in `origin` and `sync-target`.
https://github.com/tier4/autoware_launch/runs/6540294177?check_suite_focus=true#step:3:981

```
  /usr/bin/git checkout --progress sync-awf-latest --
  hint: If you meant to check out a remote tracking branch on, e.g. 'origin',
  hint: you can do so by fully qualifying the name with the --track option:
  hint: 
  hint:     git checkout --track origin/<name>
  hint: 
  hint: If you'd like to always have checkouts of an ambiguous <name> prefer
  hint: one remote, e.g. the 'origin' remote, consider setting
  hint: checkout.defaultRemote=origin in your config.
  fatal: 'sync-awf-latest' matched multiple (2) remote tracking branches
```

With this PR, it's fixed.
https://github.com/tier4/autoware_launch/runs/6542017596?check_suite_focus=true

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
