### PR TITLE
fix(colcon-build, colcon-test, clang-tidy): add rosdistro to cache key

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -73,7 +73,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ github.sha }}
+        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
 
     - name: Build
       if: ${{ steps.restore-build-files.outputs.cache-hit != 'true' }}

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -72,4 +72,4 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -73,7 +73,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
 
     - name: Test
       run: |


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

To support multi distros, I'd like to add `rosdistro` to the cache key.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
