### PR TITLE
fix(remove-exec-depend): add `-` to the pattern of package names

### DIFF
--- a/remove-exec-depend/action.yaml
+++ b/remove-exec-depend/action.yaml
@@ -6,5 +6,5 @@ runs:
   steps:
     - name: Remove exec_depend
       run: |
-        find . -name package.xml | xargs -I {} sed -i -rz "s|<exec_depend>\s*[a-zA-Z_0-9]+\s*</exec_depend>\n||g" {}
+        find . -name package.xml | xargs -I {} sed -i -rz "s|<exec_depend>\s*[a-zA-Z0-9_-]+\s*</exec_depend>\n||g" {}
       shell: bash


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Resolves #159.
Also, the order of `0-9` and `_` was flipped for visibility.

My test result is here: https://github.com/autowarefoundation/autoware-github-actions/issues/159#issuecomment-1149189998

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
