### PR TITLE
chore(deploy-docs): add mkdocstrings to requirements

### DIFF
--- a/deploy-docs/mkdocs-requirements.txt
+++ b/deploy-docs/mkdocs-requirements.txt
@@ -11,3 +11,5 @@ mike
 plantuml-markdown
 pymdown-extensions
 python-markdown-math
+mkdocstrings
+mkdocstrings[python]


### PR DESCRIPTION
Signed-off-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>

## Description
<!-- Write a brief description of this PR. -->

I'd like to use `mkdocstrings` for generating API document with the `deploy-docs` action. Merging this PR is very helpful to [CARET](https://tier4.github.io/CARET_doc/latest/) project.

It will not be harmful to your documentation repository if you don't add `mkdocstrings` to `plugins` section as below.

```
- plugins:
  - mkdocstrings:
      default_handler: python
      handlers:
        python:
          options:
            show_source: false
```


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
