### PR TITLE
feat(deploy-docs): add new input variable to select mkdocs-requirements

### DIFF
--- a/deploy-docs/README.md
+++ b/deploy-docs/README.md
@@ -25,10 +25,11 @@ jobs:
 
 ## Inputs
 
-| Name   | Required | Description                           |
-| ------ | -------- | ------------------------------------- |
-| token  | true     | The token for push to `gh-pages`.     |
-| latest | true     | Whether to create the `latest` alias. |
+| Name                | Required | Description                           |
+| ------------------- | -------- | ------------------------------------- |
+| token               | true     | The token for push to `gh-pages`.     |
+| latest              | true     | Whether to create the `latest` alias. |
+| mkdocs-requirements | false    | Optional requirements.txt for MkDocs  |
 
 ## Outputs
 

--- a/deploy-docs/README.md
+++ b/deploy-docs/README.md
@@ -25,11 +25,11 @@ jobs:
 
 ## Inputs
 
-| Name                | Required | Description                           |
-| ------------------- | -------- | ------------------------------------- |
-| token               | true     | The token for push to `gh-pages`.     |
-| latest              | true     | Whether to create the `latest` alias. |
-| mkdocs-requirements-txt | false    | `requirements.txt` for MkDocs  |
+| Name                    | Required | Description                           |
+| ----------------------- | -------- | ------------------------------------- |
+| token                   | true     | The token for push to `gh-pages`.     |
+| latest                  | true     | Whether to create the `latest` alias. |
+| mkdocs-requirements-txt | false    | `requirements.txt` for MkDocs         |
 
 ## Outputs
 

--- a/deploy-docs/README.md
+++ b/deploy-docs/README.md
@@ -29,7 +29,7 @@ jobs:
 | ------------------- | -------- | ------------------------------------- |
 | token               | true     | The token for push to `gh-pages`.     |
 | latest              | true     | Whether to create the `latest` alias. |
-| mkdocs-requirements | false    | Optional requirements.txt for MkDocs  |
+| mkdocs-requirements-txt | false    | `requirements.txt` for MkDocs  |
 
 ## Outputs
 

--- a/deploy-docs/action.yaml
+++ b/deploy-docs/action.yaml
@@ -8,7 +8,7 @@ inputs:
   latest:
     description: ""
     required: false
-  mkdocs-requirements:
+  mkdocs-requirements-txt:
     description: ""
     required: false
     default: ${GITHUB_ACTION_PATH}/mkdocs-requirements.txt

--- a/deploy-docs/action.yaml
+++ b/deploy-docs/action.yaml
@@ -8,6 +8,10 @@ inputs:
   latest:
     description: ""
     required: false
+  mkdocs-requirements:
+    description: ""
+    required: false
+    default: ${GITHUB_ACTION_PATH}/mkdocs-requirements.txt
 
 runs:
   using: composite
@@ -20,7 +24,7 @@ runs:
     - name: Install MkDocs
       run: |
         pip3 install -U wheel
-        pip3 install -r ${GITHUB_ACTION_PATH}/mkdocs-requirements.txt
+        pip3 install -r ${{ inputs.mkdocs-requirements }}
       shell: bash
 
     # TODO: Remove after v1.2.0 or v2.0.0 is released

--- a/deploy-docs/action.yaml
+++ b/deploy-docs/action.yaml
@@ -24,7 +24,7 @@ runs:
     - name: Install MkDocs
       run: |
         pip3 install -U wheel
-        pip3 install -r ${{ inputs.mkdocs-requirements }}
+        pip3 install -r ${{ inputs.mkdocs-requirements-txt }}
       shell: bash
 
     # TODO: Remove after v1.2.0 or v2.0.0 is released


### PR DESCRIPTION
Signed-off-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>

## Description

I'd like to update `deploy-docs` to give customized `mkdocs-requirements.txt`. The default requirements file `${GITHUB_ACTION_PATH}/mkdocs-requirements.txt}` will be used if users don't describe any input file.

I've tested this change with two patterns; using default `mkdocs-requirements.txt` and using customized one.

- Default requirements.txt : `${GITHUB_ACTION_PATH}/mkdocs-requirements.txt}` (like [CARET_doc](https://github.com/tier4/CARET_doc/blob/73768b43bbc555d41795579901a8005d78e4e5a3/.github/workflows/deploy-docs.yaml#L37-L41))
  - [`pip3 install`](https://github.com/tier4/CARET_doc/runs/6806496213?check_suite_focus=true#step:3:15) command was executed with `${GITHUB_ACTION_PATH}/mkdocs-requirements.txt}`
  - All packages are installed as expected ([log](https://github.com/tier4/CARET_doc/runs/6806496213?check_suite_focus=true#step:3:144))

- Customized requirements.txt :  `./mkdocs-requirements.txt` (like [CARET_analyze](https://github.com/tier4/CARET_analyze/blob/fa1c90976374a1fa28d2065cc4bbcbb89a08263b/.github/workflows/deploy-docs.yaml#L37-L42))
  -   [`pip3 install`](https://github.com/tier4/CARET_analyze/runs/6806573189?check_suite_focus=true#step:3:15) command was executed with `./mkdocs-requirements.txt`
  - All packages were installed as expected ([log](https://github.com/tier4/CARET_analyze/runs/6806573189?check_suite_focus=true#step:3:221))
  - `deploy-docs` is failed due to another reason not related to this PR

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
