### PR TITLE
fix(deploy-docs): support i18n files

### DIFF
--- a/deploy-docs/create-doc-comment.sh
+++ b/deploy-docs/create-doc-comment.sh
@@ -46,6 +46,12 @@ done
 comment_lines=("Documentation URL: $base_url")
 comment_lines+=("Modified URLs:")
 for markdown_path in "${markdown_paths[@]}"; do
+    lang=""
+    if [[ $markdown_path =~ .*\..*\.md$ ]]; then
+        lang=$(echo "$markdown_path" | sed -r 's|.*\.(\w+)\.md|\1|')/
+        markdown_path=$(echo "$markdown_path" | sed -r 's|(.*)\.\w+(\.md)|\1\2|')
+    fi
+
     if [[ $markdown_path =~ README\.md$ ]]; then
         url_path=${markdown_path/README.md/}
     elif [[ $markdown_path =~ index\.md$ ]]; then
@@ -54,7 +60,7 @@ for markdown_path in "${markdown_paths[@]}"; do
         url_path=${markdown_path/.md/\/}
     fi
 
-    comment_lines+=("- $base_url$url_path")
+    comment_lines+=("- $base_url$url_path$lang")
 done
 
 # Workaround for multiline strings


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It didn't work with the files named like `index.ja.md`.

Before:
![image](https://user-images.githubusercontent.com/31987104/173004675-396c63b7-e4cd-49e7-af23-74812c736a8b.png)

After:
![image](https://user-images.githubusercontent.com/31987104/173004733-8de650a3-9db8-4aa5-a8b5-c9f86732c1c8.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
