### PR TITLE
fix(sync-files): run pre-commands before if-condition

### DIFF
--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -117,7 +117,7 @@ runs:
                 continue
               fi
 
-              eval "$pre_commands" || true
+              eval "$pre_commands"
 
               if ! [ -f "$dest_path" ]; then
                 echo "Newly copy $source_path to $dest_path."

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -117,11 +117,12 @@ runs:
                 continue
               fi
 
+              eval "$pre_commands" || true
+
               if ! [ -f "$dest_path" ]; then
                 echo "Newly copy $source_path to $dest_path."
                 mkdir -p $(dirname "$dest_path")
 
-                eval "$pre_commands" || true
                 cp "$modified_source_path" "$dest_path"
                 eval "$post_commands"
 
@@ -129,7 +130,6 @@ runs:
               elif ! diff "$modified_source_path" "$dest_path"; then
                 echo "Copy $source_path to $dest_path."
 
-                eval "$pre_commands"
                 cp "$modified_source_path" "$dest_path"
                 eval "$post_commands"
 

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -120,7 +120,7 @@ runs:
               eval "$pre_commands"
 
               if ! [ -f "$dest_path" ]; then
-                echo "Newly copy $source_path to $dest_path."
+                echo "Newly copy $modified_source_path to $dest_path."
                 mkdir -p $(dirname "$dest_path")
 
                 cp "$modified_source_path" "$dest_path"
@@ -128,14 +128,14 @@ runs:
 
                 yq -i ".added += [\"$dest_path\"]" /tmp/result.yaml
               elif ! diff "$modified_source_path" "$dest_path"; then
-                echo "Copy $source_path to $dest_path."
+                echo "Copy $modified_source_path to $dest_path."
 
                 cp "$modified_source_path" "$dest_path"
                 eval "$post_commands"
 
                 yq -i ".changed += [\"$dest_path\"]" /tmp/result.yaml
               else
-                echo "$source_path and $dest_path are the same."
+                echo "$modified_source_path and $dest_path are the same."
                 yq -i ".not-changed += [\"$dest_path\"]" /tmp/result.yaml
               fi
             elif [ "$delete_orphaned" = "true" ]; then


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- To calculate the diff correctly, run pre-commands before if-condition.
- Remove `|| true` because it isn't planned to be used for now.
  - I think using `{dest}` in `pre-command` is a super-advanced use case.
- Fix comments.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
