### PR TITLE
fix(clang-tidy): install libomp-dev to prevent clang-diagnostic-error

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -42,7 +42,7 @@ runs:
     - name: Install Clang-Tidy
       run: |
         sudo apt-get -yqq update
-        sudo apt-get -yqq install clang-tidy
+        sudo apt-get -yqq install clang-tidy libomp-dev
       shell: bash
 
     - name: Set git config


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Without this, it causes the following error due to the `-fopenmp` option.

```
/usr/include/eigen3/Eigen/Core:70:10: error: 'omp.h' file not found [clang-diagnostic-error]
#include <omp.h>
```

> LLVM OpenMP runtime - dev package

https://packages.ubuntu.com/jammy/libomp-dev

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
