### PR TITLE
ci(clang-tidy): support target files input

### DIFF
--- a/clang-tidy/README.md
+++ b/clang-tidy/README.md
@@ -26,8 +26,8 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
         with:
           rosdistro: galactic
-          target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
+          target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
 ```
 
@@ -36,8 +36,8 @@ jobs:
 | Name                  | Required | Description                                         |
 | --------------------- | -------- | --------------------------------------------------- |
 | rosdistro             | true     | The ROS distro.                                     |
-| target-packages       | true     | The target packages to analyze by Clang-Tidy.       |
 | clang-tidy-config-url | true     | The URL to `.clang-tidy`.                           |
+| target-packages       | true     | The target packages to analyze by Clang-Tidy.       |
 | build-depends-repos   | false    | The `.repos` file that includes build dependencies. |
 | token                 | false    | The token for build dependencies and `.clang-tidy`. |
 

--- a/clang-tidy/README.md
+++ b/clang-tidy/README.md
@@ -38,6 +38,7 @@ jobs:
 | rosdistro             | true     | The ROS distro.                                     |
 | clang-tidy-config-url | true     | The URL to `.clang-tidy`.                           |
 | target-packages       | true     | The target packages to analyze by Clang-Tidy.       |
+| target-files          | false    | The target files.                                   |
 | build-depends-repos   | false    | The `.repos` file that includes build dependencies. |
 | token                 | false    | The token for build dependencies and `.clang-tidy`. |
 

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -11,6 +11,9 @@ inputs:
   target-packages:
     description: ""
     required: true
+  target-files:
+    description: ""
+    required: false
   build-depends-repos:
     description: ""
     required: false
@@ -22,9 +25,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Show target files
+    - name: Show targets
       run: |
         echo "target packages: ${{ inputs.target-packages }}"
+        echo "target files: ${{ inputs.target-files }}"
       shell: bash
 
     - name: Install curl
@@ -93,8 +97,13 @@ runs:
     - name: Get target files
       id: get-target-files
       run: |
-        package_path=$(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
-        target_files=$(find $package_path -name "*.cpp" -or -name "*.hpp")
+        if [ "${{ inputs.target-files }}" != "" ]; then
+          target_files=${{ inputs.target-files }}
+        else
+          package_path=$(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
+          target_files=$(find $package_path -name "*.cpp" -or -name "*.hpp")
+        fi
+
         echo ::set-output name=target-files::$target_files
       shell: bash
 

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -98,7 +98,7 @@ runs:
       id: get-target-files
       run: |
         if [ "${{ inputs.target-files }}" != "" ]; then
-          target_files=${{ inputs.target-files }}
+          target_files="${{ inputs.target-files }}"
         else
           package_path=$(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
           target_files=$(find $package_path -name "*.cpp" -or -name "*.hpp")

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -5,10 +5,10 @@ inputs:
   rosdistro:
     description: ""
     required: true
-  target-packages:
+  clang-tidy-config-url:
     description: ""
     required: true
-  clang-tidy-config-url:
+  target-packages:
     description: ""
     required: true
   build-depends-repos:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Currently, many files are checked in the workflow, but it's too slow.
So I'd like to support the `target-files` input to limit the target files to be analyzed.

https://github.com/autowarefoundation/autoware.universe/runs/8107659485?check_suite_focus=true#step:6:252

![image](https://user-images.githubusercontent.com/31987104/187638091-44b5848a-ccbe-4b9e-be4a-e66e3f49a892.png)

![image](https://user-images.githubusercontent.com/31987104/187637782-05f70e93-e6e2-486b-b428-63f462a8e70e.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
