### PR TITLE
feat(semantic-pull-request): disable validateSingleCommit

### DIFF
--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -29,7 +29,6 @@ jobs:
             chore
             revert
           subjectPattern: ^(?![A-Z]).+$
-          validateSingleCommit: true
           ignoreLabels: |
             bot
             ignore-semantic-pull-request


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Similar to https://github.com/autowarefoundation/autoware-github-actions/pull/148, I think we can also remove `validateSingleCommit` now. I just forgot to remove it.

`action-semantic-pull-request` ensures that the PR title is semantic.
https://github.com/amannn/action-semantic-pull-request/blob/4682b170e7c31dfbef288e994fe07853755229b4/src/index.js#L67

With this PR, we can remove this part in the pull request guidelines.
https://github.com/autowarefoundation/autoware-documentation/blob/af6c4d1b2c0747aa93f5c50899fa0c07e93b6d21/docs/contributing/pull-request-guidelines/index.md?plain=1#L74-L76

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
