### PR TITLE
feat(spell-check): support installing dict packages

### DIFF
--- a/spell-check/README.md
+++ b/spell-check/README.md
@@ -20,15 +20,18 @@ jobs:
         with:
           cspell-json-url: https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json
           local-cspell-json: .cspell.json
+          dict-packages: |
+            https://github.com/tier4/cspell-dicts
 ```
 
 ## Inputs
 
-| Name              | Required | Description                              |
-| ----------------- | -------- | ---------------------------------------- |
-| cspell-json-url   | true     | The URL to the remote `.cspell.json`.    |
-| local-cspell-json | false    | The path to the local `.cspell.json`.    |
-| token             | false    | The token for the remote `.cspell.json`. |
+| Name              | Required | Description                                           |
+| ----------------- | -------- | ----------------------------------------------------- |
+| cspell-json-url   | true     | The URL to the remote `.cspell.json`.                 |
+| local-cspell-json | false    | The path to the local `.cspell.json`.                 |
+| dict-packages     | false    | The dict packages names referenced in `.cspell.json`. |
+| token             | false    | The token for the remote `.cspell.json`.              |
 
 ## Outputs
 

--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -9,6 +9,11 @@ inputs:
     description: ""
     required: false
     default: .cspell.json
+  dict-packages:
+    description: ""
+    required: false
+    default: |
+      https://github.com/tier4/cspell-dicts
   token:
     description: ""
     required: false
@@ -17,6 +22,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install dict packages
+      run: |
+        for package in $(IFS=" " echo "${{ inputs.dict-packages }}"); do
+          echo "Install $package."
+          npm install $package
+        done
+      shell: bash
+
     - name: Retrieve remote dictionary
       run: |
         curl -fsSL -o remote.cspell.json ${{ inputs.cspell-json-url }} \


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It is useful if we can add dict packages.

Users need to import dict packages in their `.cspell.json`.

```jsonc
// .cspell.json
{
  ...
  "import": ["@tier4/cspell-dicts/cmake/cspell-ext.json"],
  ...
}
```

Related links: 
- https://github.com/tier4/cspell-dicts
- https://github.com/streetsidesoftware/cspell-dicts

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
