### PR TITLE
fix(update-codeowners-from-packages): use "**" instead of "*"

### DIFF
--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -65,7 +65,7 @@ runs:
         echo "### Automatically generated from package.xml ###" >>.github/CODEOWNERS
         for package_xml in $(find . -name package.xml | sed "s|^./||"); do
             package_dir=$(dirname "$package_xml")
-            line="$package_dir/*"
+            line="$package_dir/**"
 
             for maintainer in $(grep '<maintainer' "$package_xml" | sed -E 's|.*email="(.*)".*|\1|'); do
                 line+=" $maintainer"


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

See https://github.com/autowarefoundation/autoware.universe/pull/1788#discussion_r970224629.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
