### PR TITLE
fix(update-codeowners-from-packages): sort the order of packages

### DIFF
--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -63,7 +63,7 @@ runs:
 
         # List package maintainers
         echo "### Automatically generated from package.xml ###" >>.github/CODEOWNERS
-        for package_xml in $(find . -name package.xml | sed "s|^./||"); do
+        for package_xml in $(find . -name package.xml | sed "s|^./||" | sort); do
             package_dir=$(dirname "$package_xml")
             line="$package_dir/**"
 


### PR DESCRIPTION
Fixes https://github.com/autowarefoundation/autoware_common/pull/111#issuecomment-1254377719.
