### PR TITLE
fix(update-codeowners-from-packages): sort maintainers and remove duplicates

### DIFF
--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -67,7 +67,7 @@ runs:
             package_dir=$(dirname "$package_xml")
             line="$package_dir/**"
 
-            for maintainer in $(grep '<maintainer' "$package_xml" | sed -E 's|.*email="(.*)".*|\1|'); do
+            for maintainer in $(grep '<maintainer' "$package_xml" | sed -E 's|.*email="(.*)".*|\1|' | sort -u); do
                 line+=" $maintainer"
             done
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Found in https://github.com/autowarefoundation/autoware.universe/pull/1943.

![image](https://user-images.githubusercontent.com/31987104/192268515-bc9706d9-89c5-43db-9322-8bb7aa739b3e.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
