### PR TITLE
feat(clang-tidy, colcon-build): make CMAKE_BUILD_TYPE optional

### DIFF
--- a/clang-tidy/README.md
+++ b/clang-tidy/README.md
@@ -40,6 +40,7 @@ jobs:
 | target-packages       | true     | The target packages to analyze by Clang-Tidy.       |
 | target-files          | false    | The target files.                                   |
 | build-depends-repos   | false    | The `.repos` file that includes build dependencies. |
+| cmake-build-type      | false    | The value for `CMAKE_BUILD_TYPE`.                   |
 | token                 | false    | The token for build dependencies and `.clang-tidy`. |
 
 ## Outputs

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -17,6 +17,10 @@ inputs:
   build-depends-repos:
     description: ""
     required: false
+  cmake-build-type:
+    description: ""
+    required: false
+    default: Release
   token:
     description: ""
     required: false
@@ -85,7 +89,7 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon build --event-handlers console_cohesion+ \
           --packages-up-to ${{ inputs.target-packages }} \
-          --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       shell: bash
 
     - name: Retrieve .clang-tidy

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -85,7 +85,7 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon build --event-handlers console_cohesion+ \
           --packages-up-to ${{ inputs.target-packages }} \
-          --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       shell: bash
 
     - name: Retrieve .clang-tidy

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -85,7 +85,7 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon build --event-handlers console_cohesion+ \
           --packages-up-to ${{ inputs.target-packages }} \
-          --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       shell: bash
 
     - name: Retrieve .clang-tidy

--- a/colcon-build/README.md
+++ b/colcon-build/README.md
@@ -35,6 +35,7 @@ jobs:
 | rosdistro           | true     | ROS distro.                                         |
 | target-packages     | true     | The target packages to build.                       |
 | build-depends-repos | false    | The `.repos` file that includes build dependencies. |
+| cmake-build-type    | false    | The value for `CMAKE_BUILD_TYPE`.                   |
 | token               | false    | The token for build dependencies.                   |
 
 ## Outputs

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -62,7 +62,7 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon build --event-handlers console_cohesion+ \
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
-          --cmake-args -DCMAKE_BUILD_TYPE=Release \
+          --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           --mixin coverage-gcc coverage-pytest compile-commands
       shell: bash
 

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -62,7 +62,7 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon build --event-handlers console_cohesion+ \
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
-          --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          --cmake-args -DCMAKE_BUILD_TYPE=Debug \
           --mixin coverage-gcc coverage-pytest compile-commands
       shell: bash
 

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -11,6 +11,10 @@ inputs:
   build-depends-repos:
     description: ""
     required: false
+  cmake-build-type:
+    description: ""
+    required: false
+    default: Release
   token:
     description: ""
     required: false
@@ -62,7 +66,7 @@ runs:
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
         colcon build --event-handlers console_cohesion+ \
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
-          --cmake-args -DCMAKE_BUILD_TYPE=Debug \
+          --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }} \
           --mixin coverage-gcc coverage-pytest compile-commands
       shell: bash
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`Release` can overlook some mistakes.

Related: https://github.com/autowarefoundation/autoware.universe/issues/1959

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
