### PR TITLE
fix(clang-tidy, colcon-build, colcon-test): add cmake-build-type to cache key

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -81,7 +81,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
 
     - name: Build
       if: ${{ steps.restore-build-files.outputs.cache-hit != 'true' }}

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -76,4 +76,4 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cmake-build-type }}-${{ github.sha }}

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -77,7 +77,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
 
     - name: Test
       run: |


### PR DESCRIPTION
Probably resolves https://github.com/autowarefoundation/autoware.universe/issues/1959#issuecomment-1260731484.
