### PR TITLE
fix(clang-tidy): mark the workflow as failed if the fixes.yaml file exists

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -116,18 +116,26 @@ runs:
       run: |
         mkdir /tmp/clang-tidy-result
         clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml ${{ steps.get-target-files.outputs.target-files }} || true
-      shell: bash
-
-    - name: Save PR metadata
-      if: ${{ steps.get-target-files.outputs.target-files != '' }}
-      run: |
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt
       shell: bash
 
-    - uses: actions/upload-artifact@v3
-      if: ${{ steps.get-target-files.outputs.target-files != '' }}
+    - name: Check if the fixes.yaml file exists
+      id: check-fixes-yaml-existence
+      uses: autowarefoundation/autoware-github-actions/check-file-existence@v1
+      with:
+        files: /tmp/clang-tidy-result/fixes.yaml
+
+    - name: Upload artifacts
+      if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+      uses: actions/upload-artifact@v3
       with:
         name: clang-tidy-result
         path: /tmp/clang-tidy-result/
+
+    - name: Mark the workflow as failed if the fixes.yaml file exists
+      if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+      run: |
+        exit 1
+      shell: bash


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

To reflect the result of the `clang-tidy` command, we need to set the exit code correctly.
Currently, it's ignored.

We need to fix this condition as well: https://github.com/autowarefoundation/autoware_common/blob/efd676c788735bc74889b50558536980230b0b9d/.github/workflows/clang-tidy-pr-comments.yaml#L12

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
