### PR TITLE
feat(spell-check): add incremental-files-only option

### DIFF
--- a/spell-check/README.md
+++ b/spell-check/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This action checks if the PR has miss spellings.
+This action checks if the PR has miss spellings.  
 As it is difficult to perfectly detect all miss spellings, it is recommended not to set this as [Required](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks).
 
 ## Usage

--- a/spell-check/README.md
+++ b/spell-check/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This action checks if the PR has miss spellings.  
+This action checks if the PR has miss spellings.
 As it is difficult to perfectly detect all miss spellings, it is recommended not to set this as [Required](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks).
 
 ## Usage
@@ -22,16 +22,18 @@ jobs:
           local-cspell-json: .cspell.json
           dict-packages: |
             https://github.com/tier4/cspell-dicts
+          incremental-files-only: false
 ```
 
 ## Inputs
 
-| Name              | Required | Description                                           |
-| ----------------- | -------- | ----------------------------------------------------- |
-| cspell-json-url   | true     | The URL to the remote `.cspell.json`.                 |
-| local-cspell-json | false    | The path to the local `.cspell.json`.                 |
-| dict-packages     | false    | The dict packages names referenced in `.cspell.json`. |
-| token             | false    | The token for the remote `.cspell.json`.              |
+| Name                   | Required | Description                                                             |
+| ---------------------- | -------- | ----------------------------------------------------------------------- |
+| cspell-json-url        | true     | The URL to the remote `.cspell.json`.                                   |
+| local-cspell-json      | false    | The path to the local `.cspell.json`.                                   |
+| dict-packages          | false    | The dict packages names referenced in `.cspell.json`.                   |
+| token                  | false    | The token for the remote `.cspell.json`.                                |
+| incremental-files-only | false    | Whether limit the files checked to the ones in the pull request or push |
 
 ## Outputs
 

--- a/spell-check/README.md
+++ b/spell-check/README.md
@@ -27,12 +27,12 @@ jobs:
 
 ## Inputs
 
-| Name                   | Required | Description                                                             |
-| ---------------------- | -------- | ----------------------------------------------------------------------- |
-| cspell-json-url        | true     | The URL to the remote `.cspell.json`.                                   |
-| local-cspell-json      | false    | The path to the local `.cspell.json`.                                   |
-| dict-packages          | false    | The dict packages names referenced in `.cspell.json`.                   |
-| token                  | false    | The token for the remote `.cspell.json`.                                |
+| Name                   | Required | Description                                                      |
+| ---------------------- | -------- | ---------------------------------------------------------------- |
+| cspell-json-url        | true     | The URL to the remote `.cspell.json`.                            |
+| local-cspell-json      | false    | The path to the local `.cspell.json`.                            |
+| dict-packages          | false    | The dict packages names referenced in `.cspell.json`.            |
+| token                  | false    | The token for the remote `.cspell.json`.                         |
 | incremental-files-only | false    | Limit the files checked to the ones in the pull request or push. |
 
 ## Outputs

--- a/spell-check/README.md
+++ b/spell-check/README.md
@@ -33,7 +33,7 @@ jobs:
 | local-cspell-json      | false    | The path to the local `.cspell.json`.                                   |
 | dict-packages          | false    | The dict packages names referenced in `.cspell.json`.                   |
 | token                  | false    | The token for the remote `.cspell.json`.                                |
-| incremental-files-only | false    | Whether limit the files checked to the ones in the pull request or push |
+| incremental-files-only | false    | Limit the files checked to the ones in the pull request or push. |
 
 ## Outputs
 

--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -21,7 +21,7 @@ inputs:
   incremental-files-only:
     description: "set false if you want to check all files"
     required: false
-    default: true
+    default: "true"
 
 runs:
   using: composite

--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -18,6 +18,10 @@ inputs:
     description: ""
     required: false
     default: ${{ github.token }}
+  incremental-files-only:
+    description: "set false if you want to check all files"
+    required: false
+    default: true
 
 runs:
   using: composite
@@ -55,3 +59,4 @@ runs:
       uses: streetsidesoftware/cspell-action@v2
       with:
         config: .cspell.json
+        incremental_files_only: ${{ inputs.incremental-files-only }}

--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: ${{ github.token }}
   incremental-files-only:
-    description: "set false if you want to check all files"
+    description: ""
     required: false
     default: "true"
 


### PR DESCRIPTION
## Description

Add incremental-files-only option in spell-check workflow to check all files

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
