### PR TITLE
feat(update-codeowners-from-packages): support global codeowners

### DIFF
--- a/update-codeowners-from-packages/README.md
+++ b/update-codeowners-from-packages/README.md
@@ -36,6 +36,7 @@ If you want to combine the automatically generated `CODEOWNERS` with the manuall
 | ----------------- | -------- | ----------------------------------------------------- |
 | token             | true     | The token for pull requests.                          |
 | codeowners-manual | false    | The path to the manually maintained `CODEOWNERS`.     |
+| global-codeowners | false    | The GitHub IDs of global codeowners.                  |
 | pr-base           | false    | Refer to `peter-evans/create-pull-request`.           |
 | pr-branch         | false    | The same as above.                                    |
 | pr-title          | false    | The same as above.                                    |

--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -9,6 +9,9 @@ inputs:
     description: ""
     required: false
     default: .github/CODEOWNERS-manual
+  global-codeowners:
+    description: ""
+    required: false
   pr-base:
     description: ""
     required: false
@@ -69,6 +72,10 @@ runs:
 
             for maintainer in $(grep '<maintainer' "$package_xml" | sed -E 's|.*email="(.*)".*|\1|' | sort -u); do
                 line+=" $maintainer"
+
+                if [ -n "${{ inputs.global-codeowners }}" ]; then
+                  line+=" ${{ inputs.global-codeowners }}"
+                fi
             done
 
             echo "$line" >>.github/CODEOWNERS

--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -72,11 +72,11 @@ runs:
 
             for maintainer in $(grep '<maintainer' "$package_xml" | sed -E 's|.*email="(.*)".*|\1|' | sort -u); do
                 line+=" $maintainer"
-
-                if [ -n "${{ inputs.global-codeowners }}" ]; then
-                  line+=" ${{ inputs.global-codeowners }}"
-                fi
             done
+
+            if [ -n "${{ inputs.global-codeowners }}" ]; then
+              line+=" ${{ inputs.global-codeowners }}"
+            fi
 
             echo "$line" >>.github/CODEOWNERS
         done


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

@xmfcx wants global codeowners to bypass reviews safely.
Currently, bypassing reviews isn't supported as we desire.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
