### PR TITLE
feat: prevent a workflow from stopping when pre-commit fails

### DIFF
--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -29,8 +29,7 @@ runs:
       shell: bash
 
     - name: Push pre-commit fixes
-      # Prevent a workflow from stopping when pre-commit fails
-      if: always()
+      if: always() # Push changes even when pre-commit fails
       run: |
         if ! git diff --quiet; then
           git add -u

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -18,8 +18,23 @@ runs:
       with:
         go-version: ^1.16
 
+    - name: Install pre-commit
+      run: |
+        python -m pip install pre-commit
+      shell: bash
+
     - name: Run pre-commit
-      uses: pre-commit/action@v2.0.3
-      with:
-        extra_args: --all-files --config ${{ inputs.pre-commit-config }}
-        token: ${{ inputs.token }}
+      run: |
+        pre-commit run -a
+      shell: bash
+
+    - name: Push pre-commit fixes
+      # Prevent a workflow from stopping when pre-commit fails
+      if: always()
+      run: |
+        if ! git diff --quiet; then
+          git add -u
+          git commit -m "pre-commit fixes"
+          git push
+        fi
+      shell: bash

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -25,7 +25,7 @@ runs:
 
     - name: Run pre-commit
       run: |
-        pre-commit run -a
+        pre-commit run -a --config ${{ inputs.pre-commit-config }}
       shell: bash
 
     - name: Push pre-commit fixes


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description

Fixed workflow stopping when it failed.
For example, if there are clang-format failure and cpplint failure, workflow stops without fixing clang-format errors.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
