### PR TITLE
refactor(pre-commit): use actions instead of scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autofix_commit_msg: "ci(pre-commit): autofix"
+  autofix_commit_msg: "style(pre-commit): autofix"
   autoupdate_commit_msg: "ci(pre-commit): autoupdate"
 
 repos:

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -18,22 +18,14 @@ runs:
       with:
         go-version: ^1.16
 
-    - name: Install pre-commit
-      run: |
-        python -m pip install pre-commit
-      shell: bash
-
     - name: Run pre-commit
-      run: |
-        pre-commit run -a --config ${{ inputs.pre-commit-config }}
-      shell: bash
+      uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: --all-files --config ${{ inputs.pre-commit-config }}
+        token: ${{ steps.generate-token.outputs.token }}
 
     - name: Push pre-commit fixes
       if: always() # Push changes even when pre-commit fails
-      run: |
-        if ! git diff --quiet; then
-          git add -u
-          git commit -m "pre-commit fixes"
-          git push
-        fi
-      shell: bash
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: "ci(pre-commit): autofix"

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -28,4 +28,4 @@ runs:
       if: always() # Push changes even when pre-commit fails
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: "ci(pre-commit): autofix"
+        commit_message: "style(pre-commit): autofix"


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description

Used [pre-commit action](https://github.com/pre-commit/action) and [git-auto-commit action](https://github.com/stefanzweifel/git-auto-commit-action) instead of running scripts.

related PR

- https://github.com/autowarefoundation/autoware-github-actions/pull/197

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
