### PR TITLE
feat(clang-tidy, colcon-build, colcon-test): add include-eol-distros

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -28,7 +28,6 @@ inputs:
   include-eol-distros:
     description: ""
     required: false
-    default: "false"
 
 runs:
   using: composite

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -25,6 +25,10 @@ inputs:
     description: ""
     required: false
     default: ${{ github.token }}
+  include-eol-distros:
+    description: ""
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -70,7 +74,11 @@ runs:
       run: |
         package_paths=$(colcon list -p --packages-above-and-dependencies ${{ inputs.target-packages }} --base-paths . dependency_ws)
         sudo apt-get -yqq update
-        rosdep update
+        if [ "${{ inputs.include-eol-distros }}" = "true" ]; then
+            rosdep update --include-eol-distros
+        else
+            rosdep update
+        fi
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -22,7 +22,6 @@ inputs:
   include-eol-distros:
     description: ""
     required: false
-    default: "false"
 
 runs:
   using: composite

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -22,7 +22,7 @@ inputs:
   include-eol-distros:
     description: ""
     required: false
-    default: false
+    default: "false"
 
 runs:
   using: composite

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -55,7 +55,11 @@ runs:
       run: |
         package_paths=$(colcon list -p --packages-above-and-dependencies ${{ inputs.target-packages }} --base-paths . dependency_ws)
         sudo apt-get -yqq update
-        rosdep update ${{ inputs.rosdep-update-arguments }}
+        if [ "${{ inputs.include-eol-distros }}" = "true" ]; then
+            rosdep update --include-eol-distros
+        else
+            rosdep update
+        fi
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -19,10 +19,10 @@ inputs:
     description: ""
     required: false
     default: ${{ github.token }}
-  rosdep-update-arguments:
+  include-eol-distros:
     description: ""
     required: false
-    default: ""
+    default: false
 
 runs:
   using: composite

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: ""
     required: false
     default: ${{ github.token }}
+  rosdep-update-arguments:
+    description: ""
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -51,7 +55,7 @@ runs:
       run: |
         package_paths=$(colcon list -p --packages-above-and-dependencies ${{ inputs.target-packages }} --base-paths . dependency_ws)
         sudo apt-get -yqq update
-        rosdep update
+        rosdep update ${{ inputs.rosdep-update-arguments }}
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -22,7 +22,6 @@ inputs:
   include-eol-distros:
     description: ""
     required: false
-    default: "false"
 outputs:
   coverage-report-files:
     description: ""

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: ""
     required: false
     default: ${{ github.token }}
+  include-eol-distros:
+    description: ""
+    required: false
+    default: "false"
 outputs:
   coverage-report-files:
     description: ""
@@ -66,7 +70,11 @@ runs:
       run: |
         package_paths=$(colcon list -p --packages-above-and-dependencies ${{ inputs.target-packages }} --base-paths . dependency_ws)
         sudo apt-get -yqq update
-        rosdep update
+        if [ "${{ inputs.include-eol-distros }}" = "true" ]; then
+            rosdep update --include-eol-distros
+        else
+            rosdep update
+        fi
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 


### PR DESCRIPTION
## Description

- add argument `include-eol-distros`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
