### PR TITLE
fix(deploy-docs, delete-closed-pr-docs): remove staled argument `--rebase` of mike

### DIFF
--- a/delete-closed-pr-docs/action.yaml
+++ b/delete-closed-pr-docs/action.yaml
@@ -68,6 +68,6 @@ runs:
           git fetch
 
           echo "Delete docs version: $closed_docs_version."
-          mike delete --push --rebase "$closed_docs_version"
+          mike delete --push "$closed_docs_version"
         done
       shell: bash

--- a/deploy-docs/action.yaml
+++ b/deploy-docs/action.yaml
@@ -61,13 +61,13 @@ runs:
     - name: Deploy docs
       run: |
         git fetch
-        mike deploy --push --rebase ${{ steps.set-docs-version-name.outputs.version-name }}
+        mike deploy --push ${{ steps.set-docs-version-name.outputs.version-name }}
       shell: bash
 
     - name: Create alias 'latest'
       if: ${{ inputs.latest == 'true' }}
       run: |
-        mike deploy --push --rebase latest
+        mike deploy --push latest
       shell: bash
 
     - name: Create comment body


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
I'd like to remove `--rebase` arguments used for the `mike` command.
[`mike`](https://github.com/jimporter/mike) no longer supports the argument `--rebase` according to [its change log](https://github.com/jimporter/mike/commit/872f72def32f588908f8251fe512189e0c41f4e2).

I have tested this change in [CARET_doc] repository with applying this change ([link](https://github.com/tier4/CARET_doc/commit/4427ff5d3dc141724d9b15552f6580f0d1a7ec74)).
I have checked that this PR works properly at https://github.com/tier4/CARET_doc/pull/165. 
`deploy-docs` action ran successfully at https://github.com/tier4/CARET_doc/actions/runs/4339600632/jobs/7577349374
`delete-closed-pr-docs` action ran at https://github.com/tier4/CARET_doc/actions/runs/4339649620/jobs/7577438685#step:3:205

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
