### PR TITLE
feat(generate-chnagelog): add generate-changelog-json

### DIFF
--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -34,6 +34,7 @@ jobs:
 | git-cliff-args        | false    | The arguments for the `git-cliff` command.               |
 | git-cliff-config      | false    | The path to the `git-cliff` config file.                 |
 | trim-version-and-date | false    | Whether to trim the version and date from the changelog. |
+| save-json-output      | false    | Save the output contents to artifact in json format.     |
 
 ## Outputs
 

--- a/generate-changelog/action.yaml
+++ b/generate-changelog/action.yaml
@@ -28,9 +28,7 @@ runs:
   using: composite
   steps:
     - name: Set up git-cliff
-      uses: kenji-miyake/setup-git-cliff@v1.1.0
-      with:
-        version: 1.1.2
+      uses: kenji-miyake/setup-git-cliff@v1
 
     - name: Generate changelog
       id: generate-changelog

--- a/generate-changelog/action.yaml
+++ b/generate-changelog/action.yaml
@@ -67,7 +67,7 @@ runs:
       run: |
         git cliff --config ${{ inputs.git-cliff-config }} \
           -vv --strip all ${{ inputs.git-cliff-args }} --context --output context.json
-        
+
         # Output multiline strings: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "changelog<<$EOF" >> $GITHUB_OUTPUT

--- a/generate-changelog/action.yaml
+++ b/generate-changelog/action.yaml
@@ -14,6 +14,11 @@ inputs:
     description: ""
     required: false
     default: "true"
+  save-json-output:
+    description: ""
+    required: false
+    default: false
+
 outputs:
   changelog:
     description: ""
@@ -23,16 +28,18 @@ runs:
   using: composite
   steps:
     - name: Set up git-cliff
-      uses: kenji-miyake/setup-git-cliff@v1
+      uses: kenji-miyake/setup-git-cliff@v1.1.0
+      with:
+        version: 1.1.2
 
     - name: Generate changelog
       id: generate-changelog
       shell: bash
+      if: ${{ inputs.save-json-output == 'false' }}
       run: |
         # Generate changelog
         git cliff --output CHANGELOG.md --config ${{ inputs.git-cliff-config }} \
           -vv --strip header ${{ inputs.git-cliff-args }}
-
         r=$(cat CHANGELOG.md)
         rm CHANGELOG.md
 
@@ -41,16 +48,28 @@ runs:
           r="$(printf "$r" | tail -n +3)"
         fi
 
-        # Workaround for https://github.community/t/set-output-truncates-multiline-strings/16852
-        r="${r//'%'/'%25'}"
-        r="${r//$'\n'/'%0A'}"
-        r="${r//$'\r'/'%0D'}"
-
-        echo "::set-output name=changelog::$r"
+        delimiter="$(openssl rand -hex 8)"
+        echo "changelog<<${delimiter}" >> "${GITHUB_OUTPUT}"
+        echo $r >> "${GITHUB_OUTPUT}"
+        echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
     - name: Show result
+      shell: bash
+      if: ${{ inputs.save-json-output == 'false' }}
       run: |
         echo "$CHANGELOG"
       env:
         CHANGELOG: ${{ steps.generate-changelog.outputs.changelog }}
+
+    - name: Generate changelog JSON
+      id: generate-changelog-json
       shell: bash
+      if: ${{ inputs.save-json-output == 'true' }}
+      run: |
+        git cliff --config ${{ inputs.git-cliff-config }} \
+          -vv --strip all ${{ inputs.git-cliff-args }} --context --output context.json
+
+        delimiter="$(openssl rand -hex 8)"
+        echo "changelog<<${delimiter}" >> "${GITHUB_OUTPUT}"
+        echo $r | sed "s/'//" >> "${GITHUB_OUTPUT}"
+        echo "${delimiter}" >> "${GITHUB_OUTPUT}"

--- a/generate-changelog/action.yaml
+++ b/generate-changelog/action.yaml
@@ -73,3 +73,10 @@ runs:
         echo "changelog<<$EOF" >> $GITHUB_OUTPUT
         echo "$changelog" | sed "s/'//" >> $GITHUB_OUTPUT
         echo "$EOF" >> $GITHUB_OUTPUT
+
+    - name: Upload changelog JSON
+      id: upload-changelog-json
+      uses: actions/upload-artifact@v2
+      with:
+        name: changelog-json
+        path: ./context.json


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR enables to generate JSON changelog.
It won't change the current generate-changelog behavior.

Note that "Show result" is only for markdown changelog, not for JSON changelog.
This is because when we create a large JSON changelog and try to `echo` it, it says "Argument list too long" and CI failed

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
