### PR TITLE
docs: remove peter-evans/enable-pull-request-automerge

### DIFF
--- a/pre-commit-autoupdate/README.md
+++ b/pre-commit-autoupdate/README.md
@@ -2,7 +2,7 @@
 
 This action updates the versions of pre-commit hooks.
 
-It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests and [peter-evans/enable-pull-request-automerge](https://github.com/peter-evans/enable-pull-request-automerge) for enabling auto-merge.
+It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests.
 
 ## Usage
 

--- a/sync-branches/README.md
+++ b/sync-branches/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 This action syncs branches including remote repositories.  
-It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests and [peter-evans/enable-pull-request-automerge](https://github.com/peter-evans/enable-pull-request-automerge) for enabling auto-merge.
+It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests.
 
 Note that you need `workflow` permission for the token if you copy workflow files of GitHub Actions.
 

--- a/sync-files/README.md
+++ b/sync-files/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 This action syncs files between repositories.  
-It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests and [peter-evans/enable-pull-request-automerge](https://github.com/peter-evans/enable-pull-request-automerge) for enabling auto-merge.
+It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests.
 
 Note that you need `workflow` permission for the token if you copy workflow files of GitHub Actions.
 

--- a/update-codeowners-from-packages/README.md
+++ b/update-codeowners-from-packages/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 This action updates the `CODEOWNERS` file from ROS packages.  
-It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests and [peter-evans/enable-pull-request-automerge](https://github.com/peter-evans/enable-pull-request-automerge) for enabling auto-merge.
+It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests.
 
 Note that you need `workflow` permission for the token if you copy workflow files of GitHub Actions.
 


### PR DESCRIPTION
It was replaced by GitHub CLI.

Related:
- https://github.com/autowarefoundation/autoware-github-actions/pull/212
- https://github.com/autowarefoundation/autoware-github-actions/pull/213
- https://github.com/autowarefoundation/autoware-github-actions/pull/214
- https://github.com/autowarefoundation/autoware-github-actions/pull/216