### PR TITLE
fix(delete-closed-pr-docs): fix incorrect multiline output

### DIFF
--- a/delete-closed-pr-docs/action.yaml
+++ b/delete-closed-pr-docs/action.yaml
@@ -29,7 +29,7 @@ runs:
       id: get-docs-versions
       run: |
         echo "site_name: dummy" > mkdocs.yaml
-        echo "docs-versions=$(mike list | grep -oP "pr-\w+")" >> $GITHUB_OUTPUT
+        echo "docs-versions=$(mike list | grep -oP "pr-\w+" | tr '\n' ' ' | sed 's/\s*$//')" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Find closed docs versions


### PR DESCRIPTION
A fix for https://github.com/autowarefoundation/autoware-github-actions/pull/218.

The output of `mike list` is multiline.

```console
❯ mike list | grep -oP "pr-\w+"
pr-321
pr-317
pr-312
pr-290
pr-287
pr-279
pr-278
pr-276
pr-220
pr-195
pr-172
pr-82
```

Due to that, `echo "docs-versions=$(mike list | grep -oP "pr-\w+")" >> $GITHUB_OUTPUT` fails:

```
Run echo "site_name: dummy" > mkdocs.yaml
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'pr-335'
```

Previously, it was automatically converted into space-deliminated.
![image](https://user-images.githubusercontent.com/31987104/228413778-6b42aa07-232a-4a9e-aeab-b91dda1d7e39.png)

To be the same output as the previous one, added `tr` and `sed`:

```console
❯ mike list | grep -oP "pr-\w+" | tr '\n' ' ' | sed 's/\s*$//'
pr-321 pr-317 pr-312 pr-290 pr-287 pr-279 pr-278 pr-276 pr-220 pr-195 pr-172 pr-82⏎
```