### PR TITLE
fix(pre-commit): fix token input

### DIFF
--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -11,13 +11,23 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Run pre-commit
         uses: autowarefoundation/autoware-github-actions/pre-commit@v1
         with:
           pre-commit-config: .pre-commit-config.yaml
+          token: ${{ steps.generate-token.outputs.token }}
 ```
 
 ## Inputs

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -8,15 +8,20 @@ inputs:
   token:
     description: ""
     required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite
   steps:
+    - name: Set git config
+      uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+      with:
+        token: ${{ inputs.token }}
+
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files --config ${{ inputs.pre-commit-config }}
-        token: ${{ steps.generate-token.outputs.token }}
 
     - name: Push pre-commit fixes
       if: always() # Push changes even when pre-commit fails


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I guess the current usage is wrong because `pre-commit/action` doesn't have the `token` input: https://github.com/pre-commit/action/blob/646c83fcd040023954eafda54b4db0192ce70507/action.yml#L3

This workflow was added in https://github.com/autowarefoundation/autoware_core_universe_prototype/pull/179.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
