### PR TITLE
feat: add script to update code owners

### DIFF
--- a/update-codeowners-from-packages/README.md
+++ b/update-codeowners-from-packages/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This action updates the `CODEOWNERS` file from ROS packages.  
+This action updates the `CODEOWNERS` file from ROS packages and codeowners.yaml.
 It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/) for creating pull requests.
 
 Note that you need `workflow` permission for the token if you copy workflow files of GitHub Actions.
@@ -36,7 +36,7 @@ If you want to combine the automatically generated `CODEOWNERS` with the manuall
 | ----------------- | -------- | ----------------------------------------------------- |
 | token             | true     | The token for pull requests.                          |
 | codeowners-manual | false    | The path to the manually maintained `CODEOWNERS`.     |
-| global-codeowners | false    | The GitHub IDs of global codeowners.                  |
+| codeowners-group  | false    | The path to the group definition.                     |
 | pr-base           | false    | Refer to `peter-evans/create-pull-request`.           |
 | pr-branch         | false    | The same as above.                                    |
 | pr-title          | false    | The same as above.                                    |
@@ -49,3 +49,24 @@ If you want to combine the automatically generated `CODEOWNERS` with the manuall
 ## Outputs
 
 None.
+
+## File format
+
+codeowners.yaml
+
+```yaml
+users:
+  - "@user-name"
+  - "email.address@example.com"
+groups:
+  - "group-name"
+```
+
+codeowners-group.yaml
+
+```yaml
+group-name:
+  - user-name-1
+  - user-name-2
+  - user-name-3
+```

--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: ""
     required: false
     default: .github/CODEOWNERS-manual
-  global-codeowners:
+  codeowners-group:
     description: ""
     required: false
   pr-base:
@@ -66,20 +66,7 @@ runs:
 
         # List package maintainers
         echo "### Automatically generated from package.xml ###" >>.github/CODEOWNERS
-        for package_xml in $(find . -name package.xml | sed "s|^./||" | sort); do
-            package_dir=$(dirname "$package_xml")
-            line="$package_dir/**"
-
-            for maintainer in $(grep '<maintainer' "$package_xml" | sed -E 's|.*email="(.*)".*|\1|' | sort -u); do
-                line+=" $maintainer"
-            done
-
-            if [ -n "${{ inputs.global-codeowners }}" ]; then
-              line+=" ${{ inputs.global-codeowners }}"
-            fi
-
-            echo "$line" >>.github/CODEOWNERS
-        done
+        python ${GITHUB_ACTION_PATH}/update-code-owners.py . --groups ${{ inputs.codeowners-group }} >> .github/CODEOWNERS
       shell: bash
 
     - name: Create PR

--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -66,7 +66,7 @@ runs:
 
         # List package maintainers
         echo "### Automatically generated from package.xml ###" >>.github/CODEOWNERS
-        python ${GITHUB_ACTION_PATH}/update-code-owners.py . --groups ${{ inputs.codeowners-group }} >> .github/CODEOWNERS
+        python ${GITHUB_ACTION_PATH}/update-code-owners.py . ${{ inputs.codeowners-group }} >> .github/CODEOWNERS
       shell: bash
 
     - name: Create PR

--- a/update-codeowners-from-packages/update-code-owners.py
+++ b/update-codeowners-from-packages/update-code-owners.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yaml
+from argparse import ArgumentParser
+from collections import defaultdict
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+class CodeOwners:
+
+    def __init__(self):
+        self.maintainers = []
+        self.users = []
+        self.groups = []
+        self.parent = None
+
+    def load_package_xml(self, path: Path):
+        maintainers = ElementTree.parse(path).getroot().findall("maintainer")
+        self.maintainers = [maintainer.attrib["email"] for maintainer in maintainers]
+
+    def load_codeowners_yaml(self, path: Path):
+        data = yaml.safe_load(path.read_text())
+        self.users.extend(data.get("users", []))
+        self.groups.extend(data.get("groups", []))
+
+    def update_groups(self, groups):
+        for group in self.groups:
+            self.users.extend(groups[group])
+
+    def update_parent(self, owners, path):
+        for parent in path.parents:
+            if parent in owners:
+                self.parent = owners[parent]
+                return
+
+    def resolve_codeowners(self):
+        users = self.parent.resolve_codeowners() if self.parent else []
+        return users + self.users
+
+
+parser = ArgumentParser()
+parser.add_argument("path")
+parser.add_argument("--groups")
+args = parser.parse_args()
+root = Path(args.path)
+
+groups = yaml.safe_load(Path(args.groups).read_text()) if args.groups else {}
+owners = defaultdict(CodeOwners)
+
+for path in root.glob("**/package.xml"):
+    owners[path.parent].load_package_xml(path)
+for path in root.glob("**/codeowners.yaml"):
+    owners[path.parent].load_codeowners_yaml(path)
+
+for path in owners:
+    owners[path].update_groups(groups)
+for path in owners:
+    owners[path].update_parent(owners, path)
+
+for path in sorted(owners.keys()):
+    owner = owners[path]
+    if not owner.maintainers:
+        continue
+    users = set(owner.maintainers + owner.resolve_codeowners())
+    print(path.relative_to(root) / "**", " ".join(users))

--- a/update-codeowners-from-packages/update-code-owners.py
+++ b/update-codeowners-from-packages/update-code-owners.py
@@ -77,4 +77,4 @@ for path in sorted(owners.keys()):
     if not owner.maintainers:
         continue
     users = set(owner.maintainers + owner.resolve_codeowners())
-    print(path.relative_to(root) / "**", " ".join(users))
+    print(path.relative_to(root) / "**", " ".join(sorted(users)))

--- a/update-codeowners-from-packages/update-code-owners.py
+++ b/update-codeowners-from-packages/update-code-owners.py
@@ -55,7 +55,7 @@ class CodeOwners:
 
 parser = ArgumentParser()
 parser.add_argument("path")
-parser.add_argument("--groups")
+parser.add_argument("groups")
 args = parser.parse_args()
 root = Path(args.path)
 

--- a/update-codeowners-from-packages/update-code-owners.py
+++ b/update-codeowners-from-packages/update-code-owners.py
@@ -55,7 +55,7 @@ class CodeOwners:
 
 parser = ArgumentParser()
 parser.add_argument("path")
-parser.add_argument("groups")
+parser.add_argument("groups", nargs="?")
 args = parser.parse_args()
 root = Path(args.path)
 


### PR DESCRIPTION
## Description

Support `codeowners.yaml` file by `update-codeowners-from-packages` action . See https://github.com/autowarefoundation/autoware-github-actions/issues/236 for details.

## Related links

None.

## Tests performed

https://github.com/isamu-takagi/autoware.universe/pull/6
https://github.com/isamu-takagi/autoware.universe/pull/7

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
