### PR TITLE
feat(pre-commit): add base-branch for differential execution

### DIFF
--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -1,7 +1,7 @@
 # pre-commit
 
-This action checks if the PR passes [pre-commit](https://pre-commit.com/).  
-For public repositories, using [pre-commit.ci](https://pre-commit.ci/) is recommended.  
+This action checks if the PR passes [pre-commit](https://pre-commit.com/).
+For public repositories, using [pre-commit.ci](https://pre-commit.ci/) is recommended.
 Considering the case that you have both `.pre-commit-config.yaml` and `.pre-commit-config-optional.yaml`, this workflow takes the path to the config file.
 
 ## Usage
@@ -32,10 +32,11 @@ jobs:
 
 ## Inputs
 
-| Name              | Required | Description                            |
-| ----------------- | -------- | -------------------------------------- |
-| pre-commit-config | true     | The path to `.pre-commit-config.yaml`. |
-| token             | false    | The token for auto-fix.                |
+| Name              | Required | Description                                                             |
+| ----------------- | -------- | ----------------------------------------------------------------------- |
+| pre-commit-config | true     | The path to `.pre-commit-config.yaml`.                                  |
+| base-branch       | false    | The base branch to search for modified files. Check all files if empty. |
+| token             | false    | The token for auto-fix.                                                 |
 
 > Note: Setting `GITHUB_TOKEN` for `token` doesn't work completely because it doesn't have `workflow` permission.
 

--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -1,7 +1,7 @@
 # pre-commit
 
-This action checks if the PR passes [pre-commit](https://pre-commit.com/).
-For public repositories, using [pre-commit.ci](https://pre-commit.ci/) is recommended.
+This action checks if the PR passes [pre-commit](https://pre-commit.com/).  
+For public repositories, using [pre-commit.ci](https://pre-commit.ci/) is recommended.  
 Considering the case that you have both `.pre-commit-config.yaml` and `.pre-commit-config-optional.yaml`, this workflow takes the path to the config file.
 
 ## Usage

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -8,7 +8,7 @@ inputs:
   base-branch:
     description: ""
     required: false
-    default: ${{ github.base_ref }}
+    default: origin/${{ github.base_ref }}
   token:
     description: ""
     required: false

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -28,8 +28,7 @@ runs:
           echo "option=--all-files" >> $GITHUB_OUTPUT
           exit 0
         fi
-        target_files=$(git diff --name-only "${{ inputs.base-branch }}"...HEAD)
-        echo "option=--files ${target_files}" >> $GITHUB_OUTPUT
+        echo "option=--from-ref ${{ inputs.base-branch }} --to-ref HEAD" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get target files

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -5,14 +5,14 @@ inputs:
   pre-commit-config:
     description: ""
     required: true
-  token:
-    description: ""
-    required: false
-    default: ${{ github.token }}
   base-branch:
     description: ""
     required: false
     default: ${{ github.base_ref }}
+  token:
+    description: ""
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite
@@ -25,6 +25,8 @@ runs:
     - name: Get modified files
       id: get-modified-files
       run: |
+        git log -1 --oneline HEAD
+        git log -1 --oneline "${{ inputs.base-branch }}"
         modified_files=$(git diff --name-only "${{ inputs.base-branch }}"...HEAD)
         echo "modified-files=${modified_files}" >> $GITHUB_OUTPUT
       shell: bash

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -25,6 +25,7 @@ runs:
     - name: Get modified files
       id: get-modified-files
       run: |
+        set -e
         echo "modified-files=$(git diff --name-only "${{ inputs.base-branch }}"...HEAD)" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -18,10 +18,21 @@ runs:
       with:
         token: ${{ inputs.token }}
 
+    - name: Get modified files
+      id: get-modified-files
+      run: |
+        echo "modified-files=$(git diff --name-only "${{ inputs.base-branch }}"...HEAD)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Show result
+      run: |
+        echo "modified-files: ${{ steps.get-modified-files.outputs.modified-files }}"
+      shell: bash
+
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.0
       with:
-        extra_args: --all-files --config ${{ inputs.pre-commit-config }}
+        extra_args: --config ${{ inputs.pre-commit-config }} --files ${{ steps.get-modified-files.outputs.modified-files }}
 
     - name: Push pre-commit fixes
       if: always() # Push changes even when pre-commit fails

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -21,8 +21,8 @@ runs:
       with:
         token: ${{ inputs.token }}
 
-    - name: Set target files
-      id: set-target-files
+    - name: Set option
+      id: set-option
       run: |
         if [ -z "${{ inputs.base-branch }}" ]; then
           echo "option=--all-files" >> $GITHUB_OUTPUT
@@ -31,15 +31,10 @@ runs:
         echo "option=--from-ref ${{ inputs.base-branch }} --to-ref HEAD" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Get target files
-      run: |
-        echo "target-files-option: ${{ steps.set-target-files.outputs.option }}"
-      shell: bash
-
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.0
       with:
-        extra_args: --config ${{ inputs.pre-commit-config }} ${{ steps.set-target-files.outputs.option }}
+        extra_args: --config ${{ inputs.pre-commit-config }} ${{ steps.set-option.outputs.option }}
 
     - name: Push pre-commit fixes
       if: always() # Push changes even when pre-commit fails

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -8,7 +8,6 @@ inputs:
   base-branch:
     description: ""
     required: false
-    default: origin/${{ github.base_ref }}
   token:
     description: ""
     required: false
@@ -22,24 +21,26 @@ runs:
       with:
         token: ${{ inputs.token }}
 
-    - name: Get modified files
-      id: get-modified-files
+    - name: Set target files
+      id: set-target-files
       run: |
-        git log -1 --oneline HEAD
-        git log -1 --oneline "${{ inputs.base-branch }}"
-        modified_files=$(git diff --name-only "${{ inputs.base-branch }}"...HEAD)
-        echo "modified-files=${modified_files}" >> $GITHUB_OUTPUT
+        if [ -z "${{ inputs.base-branch }}" ]; then
+          echo "option=--all-files" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        target_files=$(git diff --name-only "${{ inputs.base-branch }}"...HEAD)
+        echo "option=--files ${target_files}" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Show result
+    - name: Get target files
       run: |
-        echo "modified-files: ${{ steps.get-modified-files.outputs.modified-files }}"
+        echo "target-files-option: ${{ steps.set-target-files.outputs.option }}"
       shell: bash
 
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.0
       with:
-        extra_args: --config ${{ inputs.pre-commit-config }} --files ${{ steps.get-modified-files.outputs.modified-files }}
+        extra_args: --config ${{ inputs.pre-commit-config }} ${{ steps.set-target-files.outputs.option }}
 
     - name: Push pre-commit fixes
       if: always() # Push changes even when pre-commit fails

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -25,8 +25,8 @@ runs:
     - name: Get modified files
       id: get-modified-files
       run: |
-        set -e
-        echo "modified-files=$(git diff --name-only "${{ inputs.base-branch }}"...HEAD)" >> $GITHUB_OUTPUT
+        modified_files=$(git diff --name-only "${{ inputs.base-branch }}"...HEAD)
+        echo "modified-files=${modified_files}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Show result

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: ""
     required: false
     default: ${{ github.token }}
+  base-branch:
+    description: ""
+    required: false
+    default: ${{ github.base_ref }}
 
 runs:
   using: composite


### PR DESCRIPTION
## Description

Add `base-branch` input to pre-commit action for differential check.

## Related links

None

## Tests performed

https://github.com/isamu-takagi/github-actions-sandbox/pull/1

## Notes for reviewers

It needs to add `fetch-depth: 0` to checkout action.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
