### PR TITLE
fix(json-schema-check): update to allow multiple schema and configuration files

### DIFF
--- a/json-schema-check/action.yaml
+++ b/json-schema-check/action.yaml
@@ -11,5 +11,5 @@ runs:
 
     - name: Check configuration files
       run: |
-        find -wholename '*/schema/*.schema.json' -execdir bash -c 'check-jsonschema --schemafile "$1" ../config/*.param.yaml' bash '{}' +
+        find -wholename '*/schema/*.schema.json' -execdir bash -c 'for f in $@; do check-jsonschema --schemafile $f ../config/`basename $f .schema.json`.param.yaml; done' bash '{}' +
       shell: bash


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Currently, `json-schema-check` only allow to validate that there is only one schema and configuration file.
Therefore, if there are multiple files test is always failed, like [this](https://github.com/autowarefoundation/autoware.universe/actions/runs/6335026322/job/17205513831).
I fixed above in this PR.

**NOTE**
As a limitation, it is required to set the same name corresponding schema and configuration file, i.e. `xxx.schema.json` and `xxx.params.yaml` 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
