### PR TITLE
feat: set author to create-pull-request action

### DIFF
--- a/pre-commit-autoupdate/action.yaml
+++ b/pre-commit-autoupdate/action.yaml
@@ -70,6 +70,7 @@ runs:
         labels: ${{ inputs.pr-labels }}
         assignees: ${{ inputs.pr-assignees }}
         reviewers: ${{ inputs.pr-reviewers }}
+        author: github-actions <github-actions@github.com>
         signoff: true
         delete-branch: true
 

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -91,6 +91,7 @@ runs:
         labels: ${{ inputs.pr-labels }}
         assignees: ${{ inputs.pr-assignees }}
         reviewers: ${{ inputs.pr-reviewers }}
+        author: github-actions <github-actions@github.com>
         signoff: true
         delete-branch: true
 

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -198,6 +198,7 @@ runs:
         labels: ${{ inputs.pr-labels }}
         assignees: ${{ inputs.pr-assignees }}
         reviewers: ${{ inputs.pr-reviewers }}
+        author: github-actions <github-actions@github.com>
         signoff: true
         delete-branch: true
 

--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -95,6 +95,7 @@ runs:
         labels: ${{ inputs.pr-labels }}
         assignees: ${{ inputs.pr-assignees }}
         reviewers: ${{ inputs.pr-reviewers }}
+        author: github-actions <github-actions@github.com>
         signoff: true
         delete-branch: true
 


### PR DESCRIPTION
## Description

The `peter-evans/create-pull-request` action uses `github.actor` as the commit author by default.
For scheduled actions, this is the user who last modified the cron section of the workflow.
Therefore, set the author to `github-actions` to indicate that it was committed by the action.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
