### PR TITLE
feat(sync-files): add source-dir option

### DIFF
--- a/sync-files/README.md
+++ b/sync-files/README.md
@@ -57,6 +57,7 @@ The specifications are:
 | --------------------- | -------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | repository            | true     | -                                            | The target repository.                                                                   |
 | ref                   | false    | The default branch of the target repository. | The version of the target repository.                                                    |
+| source-dir            | false    | Not prefixed.                                | The prefix common to `files/source`. This does not apply to the default of `files/dest`. |
 | files/source          | true     | -                                            | The path to the file in the target repository.                                           |
 | files/dest            | false    | The same as `files/source`.                  | The path where to place the synced file in the base repository.                          |
 | files/replace         | false    | `true`                                       | Whether to replace the synced file if it already exists.                                 |

--- a/sync-files/parse_config.py
+++ b/sync-files/parse_config.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import re
 from pathlib import Path
 
@@ -41,6 +42,9 @@ def main():
 
             if "post-commands" not in item:
                 item["post-commands"] = ""
+
+            if "source-dir" in repo_config:
+                item["source"] = os.path.join(repo_config["source-dir"], item["source"])
 
     print(yaml.dump(config))
 


### PR DESCRIPTION
## Description

A repository has been created by https://github.com/autowarefoundation/autoware/issues/4058 that will be the source of sync-file. In this repository, files are placed under an arbitrary directory, so add an option `source-dir` to specify the source directory.

## Tests performed

Check settings and its result here.
- https://github.com/isamu-takagi/github-actions-sandbox/blob/sync-file/.github/sync-files.yaml
- https://github.com/isamu-takagi/github-actions-sandbox/pull/5

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
