### PR TITLE
fix(update-codeowners-from-packages): add manual CODEOWNERS after package CODEOWNERS

### DIFF
--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -58,14 +58,8 @@ runs:
 
     - name: Update CODEOWNERS
       run: |
-        # Initialize CODEOWNERS
-        echo "### Copied from ${{ inputs.codeowners-manual }} ###" >.github/CODEOWNERS
-        touch ${{ inputs.codeowners-manual }}
-        cat ${{ inputs.codeowners-manual }} >> .github/CODEOWNERS
-        echo "" >>.github/CODEOWNERS
-
-        # List package maintainers
-        echo "### Automatically generated from package.xml ###" >>.github/CODEOWNERS
+        # Initialize CODEOWNERS with package maintainers
+        echo "### Automatically generated from package.xml ###" >.github/CODEOWNERS
         for package_xml in $(find . -name package.xml | sed "s|^./||" | sort); do
             package_dir=$(dirname "$package_xml")
             line="$package_dir/**"
@@ -80,6 +74,13 @@ runs:
 
             echo "$line" >>.github/CODEOWNERS
         done
+
+        # Add manually defined CODEOWNERS
+        echo "### Copied from ${{ inputs.codeowners-manual }} ###" >>.github/CODEOWNERS
+        touch ${{ inputs.codeowners-manual }}
+        cat ${{ inputs.codeowners-manual }} >> .github/CODEOWNERS
+        echo "" >>.github/CODEOWNERS
+
       shell: bash
 
     - name: Create PR

--- a/update-codeowners-from-packages/action.yaml
+++ b/update-codeowners-from-packages/action.yaml
@@ -74,12 +74,12 @@ runs:
 
             echo "$line" >>.github/CODEOWNERS
         done
+        echo "" >>.github/CODEOWNERS
 
         # Add manually defined CODEOWNERS
         echo "### Copied from ${{ inputs.codeowners-manual }} ###" >>.github/CODEOWNERS
         touch ${{ inputs.codeowners-manual }}
         cat ${{ inputs.codeowners-manual }} >> .github/CODEOWNERS
-        echo "" >>.github/CODEOWNERS
 
       shell: bash
 


### PR DESCRIPTION
## Description
modify the order to update CODEOWNER to apply manually defined CODEOWNERS first.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
