### PR TITLE
fix: unmatching yaml file checking

### DIFF
--- a/json-schema-check/validate_json_schemas.py
+++ b/json-schema-check/validate_json_schemas.py
@@ -14,7 +14,7 @@ def main():
         config_dir = os.path.dirname(schema_file).replace('schema', 'config')
 
         str_indentation = ' ' * 4
-        config_files = glob.glob(f'{config_dir}/{base_name}*.param.yaml')
+        config_files = glob.glob(f'{config_dir}/{base_name}.param.yaml')
         if not config_files:
             print(colorama.Fore.YELLOW + f'{str_indentation}No configuration files found for schema {schema_file}.')
             continue


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- Regarding `hoge.schema.json`, CI will check some unreleated .param.yaml files with the filename started by `hoge` such as `hoge_xx.param.yaml`, `hogeXXX.param.yaml`
- To fix about unneccesary checking.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
