### PR TITLE
ci(json-schema-check): allow nested config paths

### DIFF
--- a/json-schema-check/validate_json_schemas.py
+++ b/json-schema-check/validate_json_schemas.py
@@ -14,7 +14,7 @@ def main():
         config_dir = os.path.dirname(schema_file).replace('schema', 'config')
 
         str_indentation = ' ' * 4
-        config_files = glob.glob(f'{config_dir}/{base_name}*.param.yaml')
+        config_files = glob.glob(f'{config_dir}/**/{base_name}*.param.yaml', recursive=True)
         if not config_files:
             print(colorama.Fore.YELLOW + f'{str_indentation}No configuration files found for schema {schema_file}.')
             continue


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Currently, `json-schema-check` considers only specific files match: `schema/<schema_cfg_name>.schema.json` and `config/<schema_cfg_name>.param.yaml`. For packages with many config files, the config directory structure may differ. Even though the files follow naming convention, the sub directories are not taken into account. This small change in pull request adds following naming convention: `schema/<schema_cfg_name>.schema.json` and `config/<namespace>/<schema_cfg_name>.param.yaml`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Checked locally with CI script few test cases, **success** stands for `Validating ...`  and **fail** stands for `No configuration files found for schema ...` or schema was not found.

1. Expected success.
```
<package_name>
      |
      |—— schema
      |     |—— <schema_cfg_name>.schema.json
      |
      |—— config
      |     |—— <schema_cfg_name>.param.yaml
      |
```
Current: ${\color{green}SUCCESS}$
Proposed: ${\color{green}SUCCESS}$

2. Expected success.
```
<package_name>
      |
      |—— schema
      |     |—— <schema_cfg_name>.schema.json
      |
      |—— config
      |     |—— <namespace>
      |              |
      |              |—— <schema_cfg_name>.param.yaml
      |
```
Current: ${\color{red}FAIL}$
Proposed: ${\color{green}SUCCESS}$

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
