### PR TITLE
feat(sync-files): allow multiple destinations and speed up clone

### DIFF
--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -93,7 +93,7 @@ runs:
           rm -rf /tmp/repository
           git clone --depth 1 "$repository" /tmp/repository ${git_options[@]}
 
-          for dest_file in $(yq ".files[].source" /tmp/repo-config.yaml); do
+          for dest_file in $(yq ".files[].dest" /tmp/repo-config.yaml); do
             yq ".files[] | select(.dest == \"$dest_file\")" /tmp/repo-config.yaml > /tmp/file-config.yaml
 
             source_path=$(yq ".source" /tmp/file-config.yaml)

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -93,8 +93,8 @@ runs:
           rm -rf /tmp/repository
           git clone --depth 1 "$repository" /tmp/repository ${git_options[@]}
 
-          for source_file in $(yq ".files[].source" /tmp/repo-config.yaml); do
-            yq ".files[] | select(.source == \"$source_file\")" /tmp/repo-config.yaml > /tmp/file-config.yaml
+          for dest_file in $(yq ".files[].source" /tmp/repo-config.yaml); do
+            yq ".files[] | select(.dest == \"$dest_file\")" /tmp/repo-config.yaml > /tmp/file-config.yaml
 
             source_path=$(yq ".source" /tmp/file-config.yaml)
             dest_path=$(yq ".dest" /tmp/file-config.yaml)

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -91,7 +91,7 @@ runs:
           fi
 
           rm -rf /tmp/repository
-          git clone "$repository" /tmp/repository ${git_options[@]}
+          git clone --depth 1 "$repository" /tmp/repository ${git_options[@]}
 
           for source_file in $(yq ".files[].source" /tmp/repo-config.yaml); do
             yq ".files[] | select(.source == \"$source_file\")" /tmp/repo-config.yaml > /tmp/file-config.yaml

--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -93,8 +93,8 @@ runs:
           rm -rf /tmp/repository
           git clone --depth 1 "$repository" /tmp/repository ${git_options[@]}
 
-          for dest_file in $(yq ".files[].dest" /tmp/repo-config.yaml); do
-            yq ".files[] | select(.dest == \"$dest_file\")" /tmp/repo-config.yaml > /tmp/file-config.yaml
+          for file_config in $(yq ".files[].dest" /tmp/repo-config.yaml); do
+            yq ".files[] | select(.dest == \"$file_config\")" /tmp/repo-config.yaml > /tmp/file-config.yaml
 
             source_path=$(yq ".source" /tmp/file-config.yaml)
             dest_path=$(yq ".dest" /tmp/file-config.yaml)


### PR DESCRIPTION
## Description

### Speed up how?

Added ` --depth 1 ` to the `git clone` operation, performing a shallow clone, avoiding downloading entire history and branches of a repository.

It doesn't use anything more, so it should be safe.

### Why iterate over multiple destinations? What was wrong with the existing approach?

Assume the following `sync-files.yaml` configuration:

```yaml
- repository: autowarefoundation/autoware_common
  files:
    - source: .github/workflows/build-and-test.yaml
      dest: .github/workflows/build-and-test-daily.yaml
    - source: .github/workflows/build-and-test.yaml
      dest: .github/workflows/build-and-test-daily-arm64.yaml
```

It wants to copy from a source file into multiple destinations.

But when we run it with the existing configuration, it only generates the `dest: .github/workflows/build-and-test-daily-arm64.yaml` file. And completely ignores the first destination.

#### Proof
<details>
  <summary>🖱️Click here to expand🔛</summary>

![image](https://github.com/autowarefoundation/autoware-github-actions/assets/10751153/89062d68-881c-42fd-8d03-c65c3472546e)

</details>

Input:
- https://github.com/autowarefoundation/autoware.universe/actions/runs/9415404629/job/25936750262#step:3:208

It only creates arm64 version:
- https://github.com/autowarefoundation/autoware.universe/actions/runs/9415404629/job/25936750262#step:3:626

## Why does this occur?

To tackle this, I've ran https://gist.github.com/xmfcx/054a81b38ea583d39f792c6679c7bcde?permalink_comment_id=5081803#gistcomment-5081803 this script that I copied from the action itself. Put this in my autoware.universe directory.

Then put this https://gist.github.com/xmfcx/054a81b38ea583d39f792c6679c7bcde?permalink_comment_id=5081799#gistcomment-5081799 file in `/tmp/sync-files.yaml`

Also installed:
- https://github.com/chmln/sd
- https://github.com/mikefarah/yq

When I ran it, I saw:
```
source_path: .github/workflows/build-and-test.yaml
dest_path: .github/workflows/build-and-test-daily-arm64.yaml
/tmp/repository/.github/workflows/build-and-test.yaml and .github/workflows/build-and-test-daily-arm64.yaml are the same.
source_path: .github/workflows/build-and-test.yaml
dest_path: .github/workflows/build-and-test-daily-arm64.yaml
/tmp/repository/.github/workflows/build-and-test.yaml and .github/workflows/build-and-test-daily-arm64.yaml are the same.
```

Duplicate entries.

But then I ran it with the updated version from https://gist.github.com/xmfcx/054a81b38ea583d39f792c6679c7bcde?permalink_comment_id=5081803#file-sync-files-bash

And it was fixed:
```
source_path: .github/workflows/build-and-test.yaml
dest_path: .github/workflows/build-and-test-daily.yaml
/tmp/repository/.github/workflows/build-and-test.yaml and .github/workflows/build-and-test-daily.yaml are the same.
source_path: .github/workflows/build-and-test.yaml
dest_path: .github/workflows/build-and-test-daily-arm64.yaml
/tmp/repository/.github/workflows/build-and-test.yaml and .github/workflows/build-and-test-daily-arm64.yaml are the same.
```

We have both files generated.

## Effects on system behavior

I can't see this breaking any existing behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
