### PR TITLE
fix(sync-files): keep original source file intact

### DIFF
--- a/sync-files/action.yaml
+++ b/sync-files/action.yaml
@@ -103,7 +103,10 @@ runs:
             pre_commands=$(yq ".pre-commands" /tmp/file-config.yaml)
             post_commands=$(yq ".post-commands" /tmp/file-config.yaml)
 
-            modified_source_path="/tmp/repository/$source_path"
+            full_source_path="/tmp/repository/$source_path"
+
+            modified_source_path=$(mktemp)
+            cp "$full_source_path" "$modified_source_path"
 
             pre_commands=$(echo "$pre_commands" | sed "s|{source}|$modified_source_path|g" | sed "s|{dest}|$dest_path|g")
             post_commands=$(echo "$post_commands" | sed "s|{source}|$modified_source_path|g" | sed "s|{dest}|$dest_path|g")


### PR DESCRIPTION
## Description

Instead of modifying the source file in place, first copy it to a temp location with [mktemp](https://www.gnu.org/software/autogen/mktemp.html), then do all the modifications and copy to dest path as usual.

Currently it modifies the source files in place.

If multiple versions are to be created from the same source file, it will modify them multiple times, breaking files.

## Tests performed

Tested with the temporary `v-test-sync-files` tag. By calling it from:
- https://github.com/autowarefoundation/autoware.universe/pull/7340

### Without this PR

![image](https://github.com/autowarefoundation/autoware-github-actions/assets/10751153/25a1c7fc-b32c-4a18-be1b-579c448f202f)

### With this PR

![image](https://github.com/autowarefoundation/autoware-github-actions/assets/10751153/3c40376f-af46-4af1-8215-fcdc1b138be7)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
