### PR TITLE
feat(get-modified-packages): support retrieving diffs without fetching all

### DIFF
--- a/get-modified-packages/README.md
+++ b/get-modified-packages/README.md
@@ -4,15 +4,38 @@ This action get the list of ROS packages modified in the pull request.
 
 ## Usage
 
+### Basic
+
 ```yaml
 jobs:
   get-modified-packages:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Get modified packages
+        id: get-modified-packages
+        uses: autowarefoundation/autoware-github-actions/get-modified-packages@v1
+```
+
+### Fetch only the PR branch and all PR commits
+
+```yaml
+jobs:
+  get-modified-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set PR fetch depth
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: Checkout PR branch and all PR commits
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
       - name: Get modified packages
         id: get-modified-packages

--- a/get-modified-packages/action.yaml
+++ b/get-modified-packages/action.yaml
@@ -2,7 +2,7 @@ name: get-modified-packages
 description: ""
 
 inputs:
-  base-branch:
+  base-ref:
     description: ""
     required: false
     default: ${{ github.base_ref }}
@@ -20,10 +20,16 @@ runs:
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
       shell: bash
 
+    - name: Fetch the base branch with enough history for a common merge-base commit
+      run: |
+        git fetch origin ${{ inputs.base-ref }}
+      shell: bash
+
     - name: Get modified packages
       id: get-modified-packages
       run: |
-        echo "modified-packages=$(${GITHUB_ACTION_PATH}/get-modified-packages.sh origin/${{ inputs.base-branch }})" >> $GITHUB_OUTPUT
+        modified_packages=$(${GITHUB_ACTION_PATH}/get-modified-packages.sh origin/${{ inputs.base-ref }})
+        echo "modified-packages=$modified_packages" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Show result

--- a/get-modified-packages/get-modified-packages.sh
+++ b/get-modified-packages/get-modified-packages.sh
@@ -2,8 +2,6 @@
 # Search for packages that have been modified from the base branch.
 # Usage: get-modified-packages.sh <base_branch>
 
-set -e
-
 # Parse arguments
 args=()
 while [ "${1-}" != "" ]; do
@@ -15,6 +13,7 @@ while [ "${1-}" != "" ]; do
     shift
 done
 
+# example: base_branch="origin/main"
 base_branch="${args[0]}"
 
 # Check args
@@ -49,8 +48,12 @@ function find_package_dir() {
     return 1
 }
 
-# Find modified files from base branch
+# Find modified files from the base branch
 modified_files=$(git diff --name-only "$base_branch"...HEAD)
+if [ $? -ne 0 ]; then
+    echo -e "\e[31mFailed to determine modified files. Please check if the base branch exists and fetch depth is sufficient.\e[m"
+    exit 1
+fi
 
 # Find modified packages
 modified_package_dirs=()

--- a/get-modified-packages/get-modified-packages.sh
+++ b/get-modified-packages/get-modified-packages.sh
@@ -49,8 +49,7 @@ function find_package_dir() {
 }
 
 # Find modified files from the base branch
-modified_files=$(git diff --name-only "$base_branch"...HEAD)
-if [ $? -ne 0 ]; then
+if ! modified_files=$(git diff --name-only "$base_branch"...HEAD); then
     echo -e "\e[31mFailed to determine modified files. Please check if the base branch exists and fetch depth is sufficient.\e[m"
     exit 1
 fi


### PR DESCRIPTION
## Description

Continuation from:
- https://github.com/autowarefoundation/autoware.universe/pull/7408

- Renaming the input parameter name from `base-branch` to `base-ref`. (Mostly it defaults to `main`)
   - I think it is not used anywhere.
   - But we might use it for `merge_group` triggers in the future
- It will run: `git fetch origin ${{ inputs.base-ref }}` to make sure it has common merge-base commit to get diffs
- And now it is possible to only fetch the necessary commits instead of entire history of the repository. (For universe it allows time saving from about 2m30s to 6s)
- Separate the `get-modified-packages` action into 2 steps so it will report if it fails
   - Also exit with failure on the sh script.
   - `set -e` is removed from the script because it is set by default on github actions.

## Tests performed

### Failure condition

![image](https://github.com/autowarefoundation/autoware-github-actions/assets/10751153/35eeebcf-9e8e-4f25-90ab-f612c62a984f)

It fails on failure.
https://github.com/autowarefoundation/autoware.universe/actions/runs/9482100138/job/26126284417?pr=7340#step:7:29

### Success condition

![image](https://github.com/autowarefoundation/autoware-github-actions/assets/10751153/b33d2ebc-eafe-4d62-8caf-e2d8499ffc16)

And it is successful on success:
https://github.com/autowarefoundation/autoware.universe/actions/runs/9482151939/job/26126437257?pr=7340#step:7:35

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
