### PR TITLE
fix: temporary run rosdep install for all packages to detect removed packages

### DIFF
--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -59,7 +59,7 @@ runs:
         else
             rosdep update
         fi
-        DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
+        DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths dependency_ws --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 
     - name: Set up colcon-mixin


### PR DESCRIPTION
## Description

We had a situation where build-and-test-differential passed against a PR but main build CI failed after PR being merged. 
https://github.com/autowarefoundation/autoware.universe/pull/7351
https://github.com/autowarefoundation/autoware.universe/actions/runs/9451850160/job/26033742910

This is due to the change in package name, and current workflow won't be able to check packages that depends on removed package.

This PR will run rosdep against all packages in the workspace instead of only against modified packages to detect packages that still depends on removed package in the workspace. 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
