### PR TITLE
feat(make-sure-label-is-present): new workflow

### DIFF
--- a/.github/workflows/make-sure-label-is-present.yaml
+++ b/.github/workflows/make-sure-label-is-present.yaml
@@ -16,9 +16,25 @@ jobs:
     outputs:
       result: ${{ steps.make-sure-label-is-present.outputs.result }}
     steps:
+      - name: Check if new label is input label
+        id: check-if-new-label-is-input-label
+        if: github.event.label.name == inputs.label
+        run: |
+          echo "new_label_is_input_label=true" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Skip if new label is not input label
+        if: steps.check-if-new-label-is-input-label.outputs.new_label_is_input_label != 'true'
+        run: |
+          echo "Skipping execution since a different label '${{ github.event.label.name }}' is added."
+          echo "result=false" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Check if label is present
         id: make-sure-label-is-present
-        if: contains(github.event.pull_request.labels.*.name, inputs.label)
+        if: |
+          (contains(github.event.pull_request.labels.*.name, inputs.label) && 
+          steps.check-if-new-label-is-input-label.outputs.new_label_is_input_label == 'true')
         run: |
           echo "result=true" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/make-sure-label-is-present.yaml
+++ b/.github/workflows/make-sure-label-is-present.yaml
@@ -16,25 +16,9 @@ jobs:
     outputs:
       result: ${{ steps.make-sure-label-is-present.outputs.result }}
     steps:
-      - name: Check if new label is input label
-        id: check-if-new-label-is-input-label
-        if: github.event.label.name == inputs.label
-        run: |
-          echo "new_label_is_input_label=true" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Skip if new label is not input label
-        if: steps.check-if-new-label-is-input-label.outputs.new_label_is_input_label != 'true'
-        run: |
-          echo "Skipping execution since a different label '${{ github.event.label.name }}' is added."
-          echo "result=false" >> $GITHUB_OUTPUT
-        shell: bash
-
       - name: Check if label is present
         id: make-sure-label-is-present
-        if: |
-          (contains(github.event.pull_request.labels.*.name, inputs.label) &&
-          steps.check-if-new-label-is-input-label.outputs.new_label_is_input_label == 'true')
+        if: contains(github.event.pull_request.labels.*.name, inputs.label)
         run: |
           echo "result=true" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/make-sure-label-is-present.yaml
+++ b/.github/workflows/make-sure-label-is-present.yaml
@@ -1,0 +1,31 @@
+name: make-sure-label-is-present
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        required: true
+        type: string
+    outputs:
+      result:
+        value: ${{ jobs.make-sure-label-is-present.outputs.result }}
+
+jobs:
+  make-sure-label-is-present:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.make-sure-label-is-present.outputs.result }}
+    steps:
+      - name: Check if label is present
+        id: make-sure-label-is-present
+        if: contains(github.event.pull_request.labels.*.name, inputs.label)
+        run: |
+          echo "result=true" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Skip if label is not present
+        if: steps.make-sure-label-is-present.outputs.result != 'true'
+        run: |
+          echo "Please add the label '${{ inputs.label }}' to run this workflow."
+          echo "result=false" >> $GITHUB_OUTPUT
+        shell: bash

--- a/.github/workflows/make-sure-label-is-present.yaml
+++ b/.github/workflows/make-sure-label-is-present.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Check if label is present
         id: make-sure-label-is-present
         if: |
-          (contains(github.event.pull_request.labels.*.name, inputs.label) && 
+          (contains(github.event.pull_request.labels.*.name, inputs.label) &&
           steps.check-if-new-label-is-input-label.outputs.new_label_is_input_label == 'true')
         run: |
           echo "result=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

### Situation with `prevent-no-label-execution`

- Right now, if we add multiple labels to a PR, only one of them works.
- This action currently checks only if the newly added label is the correct one.
- But it should instead, check if the required label is in the labels list.

### New reusable workflow: `make-sure-label-is-present`

- It is much simpler.

## Tests performed

Being tested with:
- https://github.com/autowarefoundation/autoware_common/pull/250

## Effects on system behavior

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
