### PR TITLE
ci(colcon-build): don't cache build artifacts by default

### DIFF
--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -22,6 +22,10 @@ inputs:
   include-eol-distros:
     description: ""
     required: false
+  cache-build-artifacts:
+    description: "Caches the build and install folders for clang-tidy to use"
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -85,6 +89,7 @@ runs:
       shell: bash
 
     - name: Cache build artifacts
+      if: ${{ inputs.cache-build-artifacts == 'true' }}
       uses: actions/cache@v4
       with:
         path: |


### PR DESCRIPTION
## Description

The results of this cache action is only being used by:

https://github.com/autowarefoundation/autoware-github-actions/blob/92b81882b5e5a67da07211aa997f61f7d9f94be7/clang-tidy/action.yaml#L84-L91

To restore if there is a matching key. This aims to speed up the `clang-tidy-differential` job.

But this job is tied to a tag and is mostly unused.

And even in repositories that don't need this, it will pollute the cache with these.

Example pollution:
- https://github.com/autowarefoundation/autoware/actions/caches (nothing uses these colcon-build caches)

I would like to disable this by default and enable it wherever necessary with a new variable.

## Tests performed

Being tested here:

- https://github.com/autowarefoundation/autoware.universe/pull/7564

### `cache-build-artifacts: true`

- https://github.com/autowarefoundation/autoware.universe/actions/runs/9565791439/job/26369523062?pr=7564#step:11:5247

![image](https://github.com/autowarefoundation/autoware-github-actions/assets/10751153/4c582525-14b8-4aef-9e51-bb79ad9a3884)

![image](https://github.com/autowarefoundation/autoware-github-actions/assets/10751153/bd700a53-e7d7-4361-9122-6b8c3961e554)

### `cache-build-artifacts` is not provided (`false`)



## Effects on system behavior

Nothing should break. (new variable is not required, false by default.)

At worst, the `clang-tidy` jobs will recompile their stuff if no cache is found.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
