### PR TITLE
fix: caching strategies of colcon-build/test and clang-tidy

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -92,7 +92,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ inputs.rosdistro }}-${{ runner.arch }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
+        key: build-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
 
     - name: Build
       if: ${{ steps.restore-build-files.outputs.cache-hit != 'true' }}

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -29,8 +29,8 @@ inputs:
     description: ""
     required: false
   cache-key-element:
-    description: "Will be part of the cache key"
-    default: "default"
+    description: Will be part of the cache key
+    default: default
     required: false
 
 runs:

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -87,7 +87,7 @@ runs:
 
     - name: Restore build files from cache
       id: restore-build-files
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: |
           ./build

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -28,6 +28,10 @@ inputs:
   include-eol-distros:
     description: ""
     required: false
+  cache-key-element:
+    description: "Will be part of the cache key"
+    default: "default"
+    required: false
 
 runs:
   using: composite
@@ -88,7 +92,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
+        key: build-${{ inputs.rosdistro }}-${{ runner.arch }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
 
     - name: Build
       if: ${{ steps.restore-build-files.outputs.cache-hit != 'true' }}

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -23,8 +23,8 @@ inputs:
     description: ""
     required: false
   cache-key-element:
-    description: "Will be part of the cache key"
-    default: "default"
+    description: Will be part of the cache key
+    default: default
     required: false
 
 runs:

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -94,4 +94,4 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ inputs.rosdistro }}-${{ runner.arch }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
+        key: build-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -22,6 +22,10 @@ inputs:
   include-eol-distros:
     description: ""
     required: false
+  cache-key-element:
+    description: "Will be part of the cache key"
+    default: "default"
+    required: false
 
 runs:
   using: composite
@@ -90,4 +94,4 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
+        key: build-${{ inputs.rosdistro }}-${{ runner.arch }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -89,7 +89,7 @@ runs:
       shell: bash
 
     - name: Cache build artifacts
-      uses: actions/cache@v4
+      uses: actions/cache/save@v4
       with:
         path: |
           ./build

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -92,7 +92,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ inputs.rosdistro }}-${{ runner.arch }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
+        key: build-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
 
     - name: Test
       run: |

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -11,10 +11,6 @@ inputs:
   build-depends-repos:
     description: ""
     required: false
-  cmake-build-type:
-    description: ""
-    required: false
-    default: Release
   label-regex:
     description: ""
     required: false
@@ -25,10 +21,6 @@ inputs:
     default: ${{ github.token }}
   include-eol-distros:
     description: ""
-    required: false
-  cache-key-element:
-    description: "Will be part of the cache key"
-    default: "default"
     required: false
 outputs:
   coverage-report-files:
@@ -84,15 +76,6 @@ runs:
         fi
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
-
-    - name: Restore build files from cache
-      id: restore-build-files
-      uses: actions/cache@v4
-      with:
-        path: |
-          ./build
-          ./install
-        key: build-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
 
     - name: Test
       run: |

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -11,6 +11,10 @@ inputs:
   build-depends-repos:
     description: ""
     required: false
+  cmake-build-type:
+    description: ""
+    required: false
+    default: Release
   label-regex:
     description: ""
     required: false
@@ -21,6 +25,10 @@ inputs:
     default: ${{ github.token }}
   include-eol-distros:
     description: ""
+    required: false
+  cache-key-element:
+    description: "Will be part of the cache key"
+    default: "default"
     required: false
 outputs:
   coverage-report-files:
@@ -84,7 +92,7 @@ runs:
         path: |
           ./build
           ./install
-        key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
+        key: build-${{ inputs.rosdistro }}-${{ runner.arch }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}
 
     - name: Test
       run: |


### PR DESCRIPTION
## Description

This PR:
- Removes `restore-build-files` step from the `colcon-test`
   - It harbored a bug: `inputs.cmake-build-type` was forgotten to be defined on the action inputs, it was empty all the time and cached(saved and restored) unnecessary stuff.
   - This was added here because they thought `colcon-build` and `colcon-test` tasks could run on different jobs (different machines).
   - But it was unnecessary and everywhere, we use it like `build-and-test-x` because it is more efficient (and fast) to run them on the same machine.
   - Right now, this is also creating a bug because of the wrong cache names. Example bug:
      - noncuda and cuda `build-and-test-differential` jobs have the same cache key
      - these 2 jobs run in parallel
      - noncuda finishes first and populates the cache (with colcon-build ending)
      - cuda `colcon-test` step reuses the cache from unwanted parallel step
      - cuda tests become useless.
      - [related bug link](https://github.com/autowarefoundation/autoware.universe/pull/7712#issuecomment-2191900752)
- Makes the directions of caching clear with:
   - `colcon-build` will `actions/cache/save@v4`
      - this is important because we this cache happens after the build is done.
      - if this is not done, it might restore the cache from the previous runs of the same pr.
   - `clang-tidy` will `actions/cache/restore@v4`
      - similarly, we don't want it to reuse the cache it might generate
- Add `cache-key-element` input param to `colcon-build` and `clang-tidy` so users of this workflow can add distinctive keywords to these keys.
   - default value: `default`
   - I'll use `cuda` and `nocuda` to differentiate between these but in future users could reuse it in different ways
- Changed the order of key elements and removed `runner.os` identifier.
   - 🪦`key: build-${{ inputs.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cmake-build-type }}-${{ github.sha }}`
   - 🐣`key: build-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ inputs.cache-key-element }}-${{ inputs.cmake-build-type }}-${{ github.sha }}`

## Tests performed

Performed the tests in:
- https://github.com/autowarefoundation/autoware.universe/pull/7712

## Effects on system behavior

- Since this is all cache related, all workflows using this can keep using it without making any changes.

## Interface changes

- I'm not changing any default input/output of these actions
   - Adding an optional `cache-key-element` input with default value of `default`
      - Will just add a keyword to the caches

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
