### PR TITLE
fix(clang-tidy): make clang-tidy workflow fail only when it reports errors

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -126,7 +126,7 @@ runs:
       if: ${{ steps.get-target-files.outputs.target-files != '' }}
       run: |
         mkdir /tmp/clang-tidy-result
-        clang-tidy -p build/ ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.txt || true
+        clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.txt || true
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt
@@ -138,8 +138,14 @@ runs:
       with:
         files: /tmp/clang-tidy-result/report.txt
 
+    - name: Check if the fixes.yaml file exists
+      id: check-fixes-yaml-existence
+      uses: autowarefoundation/autoware-github-actions/check-file-existence@v1
+      with:
+        files: /tmp/clang-tidy-result/fixes.yaml
+
     - name: Upload artifacts
-      if: ${{ steps.check-report-txt-existence.outputs.exists == 'true' }}
+      if: ${{ steps.check-report-txt-existence.outputs.exists == 'true' && steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: clang-tidy-result

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -126,27 +126,29 @@ runs:
       if: ${{ steps.get-target-files.outputs.target-files != '' }}
       run: |
         mkdir /tmp/clang-tidy-result
-        clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml ${{ steps.get-target-files.outputs.target-files }} || true
+        clang-tidy -p build/ ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.txt || true
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt
       shell: bash
 
-    - name: Check if the fixes.yaml file exists
-      id: check-fixes-yaml-existence
+    - name: Check if the report.txt file exists
+      id: check-report-txt-existence
       uses: autowarefoundation/autoware-github-actions/check-file-existence@v1
       with:
-        files: /tmp/clang-tidy-result/fixes.yaml
+        files: /tmp/clang-tidy-result/report.txt
 
     - name: Upload artifacts
-      if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+      if: ${{ steps.check-report-txt-existence.outputs.exists == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: clang-tidy-result
         path: /tmp/clang-tidy-result/
 
-    - name: Mark the workflow as failed if the fixes.yaml file exists
-      if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+    - name: Mark the workflow as failed if clang-tidy find an error
+      if: ${{ steps.check-report-txt-existence.outputs.exists == 'true' }}
       run: |
-        exit 1
+        if [ -n "$(grep ": error:" /tmp/clang-tidy-result/report.txt)" ]; then
+          exit 1
+        fi
       shell: bash


### PR DESCRIPTION
## Description

**Related PR:**
- https://github.com/autowarefoundation/autoware.universe/pull/7729#issuecomment-2195994727

The current clang-tidy fails when there exists a `fixes.yaml`.
It leads to the CI failure even when clang-tidy reports only warnings.
I have changed it so that the CI fails only when it reports errors.

@xmfcx 
The way I used whether clang-tidy reports an errors is the following:
```
if [ -n "$(grep ": error:" /tmp/clang-tidy-result/report.txt)" ];
```
I'm not sure there is a better way, so please review it carefully. Thank you in advance!

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
