### PR TITLE
chore(colcon-test): ignore test directory in colcon lcov-result

### DIFF
--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -94,6 +94,7 @@ runs:
 
         colcon lcov-result \
           --verbose \
+          --filter "*/test/*" \
           --packages-above ${{ inputs.target-packages }} || true
 
         colcon coveragepy-result \


### PR DESCRIPTION
## Description

When displaying coverage, I believe it's generally unnecessary to include the coverage of the test files themselves. Therefore, in this PR, I've configured the settings to exclude them.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
