### PR TITLE
feat(colcon-build): use nice command to not overuse resources

### DIFF
--- a/colcon-build/README.md
+++ b/colcon-build/README.md
@@ -30,13 +30,16 @@ jobs:
 
 ## Inputs
 
-| Name                | Required | Description                                         |
-| ------------------- | -------- | --------------------------------------------------- |
-| rosdistro           | true     | ROS distro.                                         |
-| target-packages     | true     | The target packages to build.                       |
-| build-depends-repos | false    | The `.repos` file that includes build dependencies. |
-| cmake-build-type    | false    | The value for `CMAKE_BUILD_TYPE`.                   |
-| token               | false    | The token for build dependencies.                   |
+| Name                | Required | Description                                                                  |
+|---------------------| -------- |------------------------------------------------------------------------------|
+| rosdistro           | true     | ROS distro.                                                                  |
+| target-packages     | true     | The target packages to build.                                                |
+| build-depends-repos | false    | The `.repos` file that includes build dependencies.                          |
+| cmake-build-type    | false    | The value for `CMAKE_BUILD_TYPE`.                                            |
+| token               | false    | The token for build dependencies.                                            |
+| include-eol-distros | false    | If true, adds `--include-eol-distros` to `rosdep update`.                    |
+| cache-key-element   | false    | This value is added to the github actions cache key.                         |
+| nice-command        | false    | This command is prepended to the `colcon build` to avoid draining resources. |
 
 ## Outputs
 

--- a/colcon-build/README.md
+++ b/colcon-build/README.md
@@ -31,7 +31,7 @@ jobs:
 ## Inputs
 
 | Name                | Required | Description                                                                  |
-|---------------------| -------- |------------------------------------------------------------------------------|
+| ------------------- | -------- | ---------------------------------------------------------------------------- |
 | rosdistro           | true     | ROS distro.                                                                  |
 | target-packages     | true     | The target packages to build.                                                |
 | build-depends-repos | false    | The `.repos` file that includes build dependencies.                          |

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -26,6 +26,10 @@ inputs:
     description: Will be part of the cache key
     default: default
     required: false
+  nice-command:
+    description: "See `man nice` for details"
+    required: false
+    default: "nice -n 19"
 
 runs:
   using: composite
@@ -80,7 +84,7 @@ runs:
         cat /etc/nsswitch.conf
         sed -e 's#hosts:\(.*\)dns\(.*\)#hosts:\1\2#g' -i.bak /etc/nsswitch.conf
         cat /etc/nsswitch.conf
-        colcon build --event-handlers console_cohesion+ \
+        ${{ inputs.nice-command }} colcon build --event-handlers console_cohesion+ \
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
           --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }} \
           --mixin coverage-gcc coverage-pytest compile-commands

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -27,9 +27,9 @@ inputs:
     default: default
     required: false
   nice-command:
-    description: "See `man nice` for details"
+    description: See `man nice` for details
     required: false
-    default: "nice -n 19"
+    default: nice -n 19
 
 runs:
   using: composite


### PR DESCRIPTION
## Description

`nice` is part of GNU coreutils, let's you run a program with modified scheduling priority.

Comes bundled in the our Ubuntu containers.

This PR aims to utilize it to prevent `colcon build` from overusing the runner resources.

[man page](https://manpages.ubuntu.com/manpages/jammy/en/man1/nice.1.html)

> Run COMMAND with an adjusted niceness, which affects process scheduling.  With no COMMAND,
> print the current niceness.  Niceness  values  range  from  **-20**  (most  favorable  to  the
> process) to **19** (least favorable to the process).

I set the default to be 19 in this PR.

Original default was 10.

Related PR:

- https://github.com/autowarefoundation/autoware.universe/pull/8498

Failure example for a runner due to over-usage of a machine during colcon build:
- https://github.com/autowarefoundation/autoware.universe/actions/runs/10419516744/attempts/1

   > [build-and-test-codebuild (humble, -cuda)](https://github.com/autowarefoundation/autoware.universe/actions/runs/10419516744/job/28857726704)
   > The self-hosted runner: ed3beb09-f7b2-47dc-a3e2-f94fed279d09 lost communication with the server. Verify the machine is running and has a healthy network connection. **Anything in your workflow that** terminates the runner process, **starves it for CPU**/Memory, or blocks its network access **can cause this error.**

## Tests performed

- Build was successful:
   - https://github.com/autowarefoundation/autoware.universe/actions/runs/10450884453/job/28936135748
   - test failed but it's a known issue, not related to this.
   - https://github.com/autowarefoundation/autoware.universe/pull/8529

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
