### PR TITLE
refactor(colcon-build): nice-command to build-pre-command

### DIFF
--- a/colcon-build/README.md
+++ b/colcon-build/README.md
@@ -39,7 +39,7 @@ jobs:
 | token                        | false    | The token for build dependencies.                                                                                       |
 | include-eol-distros          | false    | If true, adds `--include-eol-distros` to `rosdep update`.                                                               |
 | cache-key-element            | false    | This value is added to the github actions cache key.                                                                    |
-| nice-command                 | false    | This command is prepended to the `colcon build` to avoid draining resources.                                            |
+| build-pre-command            | false    | This command is prepended to the `colcon build` to avoid draining resources.                                            |
 | colcon-parallel-workers-flag | false    | Will be appended to the colcon build command to limit number of packages built in parallel. e.g. "--parallel-workers 3" |
 | makeflags                    | false    | Will be exported as MAKEFLAGS environment variable for colcon build step. e.g. "-j 4"                                   |
 

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -26,8 +26,8 @@ inputs:
     description: Will be part of the cache key
     default: default
     required: false
-  nice-command:
-    description: See `man nice` for details
+  build-pre-command:
+    description: Will be prepended to the colcon build command. e.g. "nice -n 19" or "taskset --cpu-list 0-2"
     required: false
     default: nice -n 19
   colcon-parallel-workers-flag:
@@ -94,7 +94,7 @@ runs:
         cat /etc/nsswitch.conf
         MAKEFLAGS="${{ inputs.makeflags }}"
         echo "MAKEFLAGS=$MAKEFLAGS"  # for debugging
-        ${{ inputs.nice-command }} colcon build ${{ inputs.colcon-parallel-workers-flag }} \
+        ${{ inputs.build-pre-command }} colcon build ${{ inputs.colcon-parallel-workers-flag }} \
           --event-handlers console_cohesion+ \
           --packages-above-and-dependencies ${{ inputs.target-packages }} \
           --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }} \


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware-github-actions/pull/309

This PR tries to limit the number of CPUs used by the runner.

But instead of using the usual `--parallel-workers 3` or `MAKEFLAGS=-j4` that limit the ways we can pick how many cores are assigned, we can also make use of `taskset --cpu-list 0-4 colcon build ...` which will use first 5 cores.

Since we already added the `nice-command` as a pre-command for the colcon build, let's generalize it so we can use it with this purpose as well.

Related:
- https://github.com/autowarefoundation/autoware.universe/pull/8498

## Tests performed

- https://github.com/autowarefoundation/autoware.universe/actions/runs/10468690696/job/28990143275?pr=8498#step:13:310

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
