### PR TITLE
feat(spell-check): replace spell-check dictionaries to use AWf repositories

### DIFF
--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -13,4 +13,4 @@ jobs:
       - name: Run spell-check
         uses: autowarefoundation/autoware-github-actions/spell-check@v1
         with:
-          cspell-json-url: https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json
+          cspell-json-url: https://raw.githubusercontent.com/autowarefoundation/autoware-spell-check-dict/main/.cspell.json

--- a/spell-check/README.md
+++ b/spell-check/README.md
@@ -18,7 +18,7 @@ jobs:
       - name: Run spell-check
         uses: autowarefoundation/autoware-github-actions/spell-check@v1
         with:
-          cspell-json-url: https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json
+          cspell-json-url: https://raw.githubusercontent.com/autowarefoundation/autoware-spell-check-dict/main/.cspell.json
           local-cspell-json: .cspell.json
           dict-packages: |
             https://github.com/tier4/cspell-dicts

--- a/spell-check/action.yaml
+++ b/spell-check/action.yaml
@@ -13,8 +13,8 @@ inputs:
     description: ""
     required: false
     default: |
-      https://github.com/tier4/autoware-spell-check-dict
-      https://github.com/tier4/cspell-dicts
+      https://github.com/autowarefoundation/autoware-spell-check-dict
+      https://github.com/autowarefoundation/cspell-dicts
   token:
     description: ""
     required: false


### PR DESCRIPTION
## Description
This modifies spell-check actions to use the dictionaries from AWF repository instead of TIER IV dictionaries so that we have full control over addition/deletion of words in the dictionaries without waiting approval from TIER IV.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
