### PR TITLE
fix(test-composite-actions): use newer ghcr image

### DIFF
--- a/.github/workflows/test-composite-actions.yaml
+++ b/.github/workflows/test-composite-actions.yaml
@@ -146,7 +146,8 @@ jobs:
       matrix:
         container:
           - ros:humble
-          - ghcr.io/autowarefoundation/autoware-universe:humble-latest
+          - ghcr.io/autowarefoundation/autoware:latest-autoware-universe
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Fix not to use outdated image in the workflow.

## Related links

Not provided.

## Tests performed

(I'll put after tests as this PR needs to run the workflows)

## Notes for reviewers



## Interface changes

No interface change exists in this PR

### ROS Topic Changes

No change exists in this PR.

### ROS Parameter Changes

No change exists in this PR.

## Effects on system behavior

The failing workflow ```test-composite-actions``` will succeed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
