### PR TITLE
build(deploy-docs): add pathspec as dependency

### DIFF
--- a/deploy-docs/mkdocs-requirements.txt
+++ b/deploy-docs/mkdocs-requirements.txt
@@ -10,6 +10,7 @@ mkdocs-same-dir
 mkdocs-static-i18n
 mkdocs-video
 mike
+pathspec
 plantuml-markdown
 pymdown-extensions
 python-markdown-math


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware-documentation/pull/615

[failed](https://github.com/autowarefoundation/autoware-documentation/actions/runs/10936828636/job/30373333905?pr=615#step:3:417) today. 

```
error: No module named 'pathspec'
Error: Process completed with exit code 1.
```

This PR attempts to fix this. (Not sure why it happened)

## Tests performed

Will test in:
- https://github.com/autowarefoundation/autoware-documentation/pull/615

to test this temporarily.

## Effects on system behavior

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
