### PR TITLE
feat(clang-tidy): use autoware-clang-tidy

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -109,7 +109,7 @@ runs:
       if: ${{ inputs.target-packages != '' }}
       run: |
         mkdir /tmp/clang-tidy-result
-        ament_clang_tidy --export-fixes /tmp/clang-tidy-result/fixes.yaml --packages-select ${{ inputs.target-packages }} > /tmp/clang-tidy-result/report.txt || true
+        ament_clang_tidy --export-fixes /tmp/clang-tidy-result/fixes.yaml --packages-select ${{ inputs.target-packages }} --jobs $(nproc) > /tmp/clang-tidy-result/report.txt || true
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -120,6 +120,7 @@ runs:
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
+      if: ${{ inputs.target-packages != '' }}
       with:
         name: clang-tidy-result
         path: /tmp/clang-tidy-result/

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -95,7 +95,7 @@ runs:
       if: ${{ steps.restore-build-files.outputs.cache-hit != 'true' }}
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
-        colcon build --event-handlers console_cohesion+ \
+        colcon build --symlink-install --event-handlers console_cohesion+ \
           --packages-up-to ${{ inputs.target-packages }} \
           --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       shell: bash

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -11,9 +11,6 @@ inputs:
   target-packages:
     description: ""
     required: true
-  target-files:
-    description: ""
-    required: false
   build-depends-repos:
     description: ""
     required: false
@@ -39,7 +36,6 @@ runs:
     - name: Show targets
       run: |
         echo "target packages: ${{ inputs.target-packages }}"
-        echo "target files: ${{ inputs.target-files }}"
       shell: bash
 
     - name: Install curl
@@ -54,10 +50,10 @@ runs:
         sudo apt-get -yqq install python3-pip
       shell: bash
 
-    - name: Install Clang-Tidy
+    - name: Install ament_clang_tidy
       run: |
         sudo apt-get -yqq update
-        sudo apt-get -yqq install clang-tidy libomp-dev
+        sudo apt-get -yqq install ros-${{ inputs.rosdistro }}-ament-clang-tidy libomp-dev
       shell: bash
 
     - name: Set git config
@@ -109,24 +105,11 @@ runs:
           -H "Authorization: token ${{ inputs.token }}"
       shell: bash
 
-    - name: Get target files
-      id: get-target-files
-      run: |
-        if [ "${{ inputs.target-files }}" != "" ]; then
-          target_files="${{ inputs.target-files }}"
-        else
-          package_path=$(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
-          target_files=$(find $package_path -name "*.cpp" -or -name "*.hpp")
-        fi
-
-        echo "target-files=$target_files" >> $GITHUB_OUTPUT
-      shell: bash
-
     - name: Analyze
-      if: ${{ steps.get-target-files.outputs.target-files != '' }}
+      if: ${{ inputs.target-packages != '' }}
       run: |
         mkdir /tmp/clang-tidy-result
-        clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.txt || true
+        ament_clang_tidy --export-fixes /tmp/clang-tidy-result/fixes.yaml --packages-select ${{ inputs.target-packages }} > /tmp/clang-tidy-result/report.txt || true
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -53,7 +53,8 @@ runs:
     - name: Install ament_clang_tidy
       run: |
         sudo apt-get -yqq update
-        sudo apt-get -yqq install ros-${{ inputs.rosdistro }}-ament-clang-tidy libomp-dev
+        sudo apt-get -yqq install clang-tidy libomp-dev
+        pip install git+https://github.com/yhisaki/autoware-clang-tidy.git
       shell: bash
 
     - name: Set git config
@@ -107,37 +108,23 @@ runs:
 
     - name: Analyze
       if: ${{ inputs.target-packages != '' }}
+      continue-on-error: true
+      id: clang-tidy-analysis
       run: |
         mkdir /tmp/clang-tidy-result
-        ament_clang_tidy --export-fixes /tmp/clang-tidy-result/fixes.yaml --packages-select ${{ inputs.target-packages }} --jobs $(nproc) > /tmp/clang-tidy-result/report.txt || true
+        autoware-clang-tidy --export-fixes /tmp/clang-tidy-result/fixes.yaml --packages-select ${{ inputs.target-packages }} --jobs $(nproc) --output-dir /tmp/clang-tidy-result/
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt
       shell: bash
 
-    - name: Check if the report.txt file exists
-      id: check-report-txt-existence
-      uses: autowarefoundation/autoware-github-actions/check-file-existence@v1
-      with:
-        files: /tmp/clang-tidy-result/report.txt
-
-    - name: Check if the fixes.yaml file exists
-      id: check-fixes-yaml-existence
-      uses: autowarefoundation/autoware-github-actions/check-file-existence@v1
-      with:
-        files: /tmp/clang-tidy-result/fixes.yaml
-
     - name: Upload artifacts
-      if: ${{ steps.check-report-txt-existence.outputs.exists == 'true' && steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: clang-tidy-result
         path: /tmp/clang-tidy-result/
 
     - name: Mark the workflow as failed if clang-tidy find an error
-      if: ${{ steps.check-report-txt-existence.outputs.exists == 'true' }}
-      run: |
-        if [ -n "$(grep ": error:" /tmp/clang-tidy-result/report.txt)" ]; then
-          exit 1
-        fi
+      if: steps.clang-tidy-analysis.outcome == 'failure'
+      run: exit 1
       shell: bash


### PR DESCRIPTION
## Description

This PR changes the approach from using clang-tidy directly to using [autoware-clang-tidy](https://github.com/yhisaki/autoware-clang-tidy) instead. Clang-tidy will be executed on the packages specified in `target-packages`.

## Tests performed

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
