### PR TITLE
feat: attach `git diff` in the PR description

### DIFF
--- a/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
+++ b/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
@@ -358,6 +358,7 @@ def main(args: argparse.Namespace) -> None:
 This PR updates the version of the repository {repo_name} in autoware.repos.
 
 ## What's changed
+
 You can see the changes in https://github.com/{repo_name}/compare/{current_version}...{latest_tag}.
 '''
 

--- a/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
+++ b/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
@@ -358,7 +358,7 @@ def main(args: argparse.Namespace) -> None:
 This PR updates the version of the repository {repo_name} in autoware.repos.
 
 ## What's changed
-You can see the changes in its [git diff](https://github.com/{repo_name}/compare/{current_version}...{latest_tag}).
+You can see the changes in https://github.com/{repo_name}/compare/{current_version}...{latest_tag}.
 '''
 
             # Create a PR

--- a/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
+++ b/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
@@ -358,7 +358,7 @@ def main(args: argparse.Namespace) -> None:
 This PR updates the version of the repository {repo_name} in autoware.repos.
 
 ## What's changed
-You can see the changes in [git diff of the {repo_name}](https://github.com/{repo_name}/compare/{current_version}...{latest_tag}).
+You can see the changes in its [git diff](https://github.com/{repo_name}/compare/{current_version}...{latest_tag}).
 '''
 
             # Create a PR

--- a/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
+++ b/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
@@ -353,11 +353,19 @@ def main(args: argparse.Namespace) -> None:
             # Switch back to base branch
             repo.heads[args.base_branch].checkout()
 
+            # Compose a PR body
+            pr_body = f'''## Description
+This PR updates the version of the repository {repo_name} in autoware.repos.
+
+## What's changed
+You can see the changes in [git diff of the {repo_name}](https://github.com/{repo_name}/compare/{current_version}...{latest_tag}).
+'''
+
             # Create a PR
             github_interface.create_pull_request(
                 repo_name = args.repo_name,
                 title = title,
-                body = f"This PR updates the version of the repository {repo_name} in autoware.repos",
+                body = pr_body,
                 head = branch_name,
                 base = args.base_branch
             )


### PR DESCRIPTION
## Description

This PR fixes so the version update PR contains the `git diff` of the target repository.
Currently the version update PR contains poor information in its description [as this](https://github.com/autowarefoundation/autoware/pull/5304) and this makes the review difficult.

## Related links

[Discussion for feature improvement](https://github.com/orgs/autowarefoundation/discussions/5305)

## Tests performed

~~After the PR author finishes their tests, this will be updated.~~

I verified that a PR is created as [this](https://github.com/autowarefoundation/autoware_dummy_repository/pull/112). The PR contains the `git diff` so I believe this is enough as tests.

## Notes for reviewers

Currently, the version update PR does not contain `git diff` and the reviewer needs to go to the target repository by themselves. This PR reduces such the additional task.

## Interface changes

No interface changes.

### ROS Topic Changes

No ROS topic changes.

### ROS Parameter Changes

No ROS parameter changes.

## Effects on system behavior

The version update PR will be containing additional information (`git diff`).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
