### PR TITLE
fix(github-runner): fix to use ubuntu-22.04

### DIFF
--- a/.github/workflows/actions-tagger.yaml
+++ b/.github/workflows/actions-tagger.yaml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   actions-tagger:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: Actions-R-Us/actions-tagger@v2

--- a/.github/workflows/check-secret.yaml
+++ b/.github/workflows/check-secret.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check-secret:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       set: ${{ steps.check-secret.outputs.set }}
     steps:

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   github-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set tag name
         id: set-tag-name

--- a/.github/workflows/make-sure-label-is-present.yaml
+++ b/.github/workflows/make-sure-label-is-present.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   make-sure-label-is-present:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       result: ${{ steps.make-sure-label-is-present.outputs.result }}
     steps:

--- a/.github/workflows/pre-commit-optional.yaml
+++ b/.github/workflows/pre-commit-optional.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pre-commit-optional:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/prevent-no-label-execution.yaml
+++ b/.github/workflows/prevent-no-label-execution.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   prevent-no-label-execution:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       run: ${{ steps.prevent-no-label-execution.outputs.run }}
     steps:

--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   semantic-pull-request:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   spell-check-differential:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -14,7 +14,7 @@ jobs:
   sync-files:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/test-composite-actions.yaml
+++ b/.github/workflows/test-composite-actions.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-register-autonomoustuff-repository:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ros:${{ matrix.rosdistro }}
     strategy:
       fail-fast: false
@@ -34,7 +34,7 @@ jobs:
           rosdep resolve pacmod3_msgs
 
   test-clang-tidy-empty-target:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ros:${{ matrix.rosdistro }}
     strategy:
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
           clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
 
   test-check-file-existence:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
           [[ "${{ steps.check-file-existence4.outputs.exists }}" == "true" ]]
 
   test-colcon-build-and-colcon-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ros:${{ matrix.rosdistro }}
     strategy:
       fail-fast: false
@@ -139,7 +139,7 @@ jobs:
           target-packages: empty_target_cmake empty_target_python
 
   test-get-self-packages-and-get-modified-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
   sync-files:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/check-file-existence/README.md
+++ b/check-file-existence/README.md
@@ -9,7 +9,7 @@ This action checks if the specified files exist.
 ```yaml
 jobs:
   check-file-existence:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check file existence
         id: check-file-existence

--- a/clang-tidy/README.md
+++ b/clang-tidy/README.md
@@ -8,7 +8,7 @@ This workflow depends on `colcon-build` action.
 ```yaml
 jobs:
   clang-tidy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ros:galactic
     needs: build-and-test
     steps:

--- a/colcon-build/README.md
+++ b/colcon-build/README.md
@@ -7,7 +7,7 @@ This action runs `colcon build`.
 ```yaml
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ros:galactic
     steps:
       - name: Check out repository

--- a/colcon-test/README.md
+++ b/colcon-test/README.md
@@ -8,7 +8,7 @@ Note that you need to build target packages before running this action.
 ```yaml
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ros:galactic
     steps:
       - name: Check out repository
@@ -30,7 +30,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ros:galactic
     strategy:
       matrix:

--- a/create-prs-to-update-vcs-repositories/README.md
+++ b/create-prs-to-update-vcs-repositories/README.md
@@ -22,7 +22,7 @@ These secrets are already set if inside of the autoware repository.
 ```yaml
 jobs:
   sync-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/create-prs-to-update-vcs-repositories/README.md
+++ b/create-prs-to-update-vcs-repositories/README.md
@@ -37,6 +37,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           repo_name: autowarefoundation/autoware
           parent_dir: .
+          targets: major minor
           base_branch: main
           new_branch_prefix: feat/update-
           autoware_repos_file_name: autoware.repos
@@ -49,6 +50,7 @@ jobs:
 | ------------------------ | -------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | token                    | true     |                | The token for pull requests.                                                                                                  |
 | repo_name                | true     |                | The name of the repository to create pull requests.                                                                           |
+| targets                  | false    | any            | The target release types (choices: any, patch, minor, major).                                                                 |
 | parent_dir               | false    | .              | The parent directory of the repository.                                                                                       |
 | base_branch              | false    | main           | The base branch to create pull requests.                                                                                      |
 | new_branch_prefix        | false    | feat/update-   | The prefix of the new branch name. The branch name will be `{new_branch_prefix}-{user_name}/{repository_name}/{new_version}`. |
@@ -58,3 +60,48 @@ jobs:
 ## Outputs
 
 None.
+
+## What kind of tags are handled?
+
+- Monitors all vcs-imported repositories in the `autoware.repos` (if default) which have a version with regular expression pattern `r'\b(?<![^\s])\d+\.\d+\.\d+(?![-\w.+])\b'`.
+  - This pattern match/mismatches for the following examples:
+
+```plaintext
+        "0.0.1",                # match
+        "0.1.0",                # match
+        "1.0.0",                # match
+        "2.1.1",                # match
+        "v0.0.1",               # mismatch
+        "ros2-v0.0.4",          # mismatch
+        "xxx-1.0.0-yyy",        # mismatch
+        "v1.2.3-beta",          # mismatch
+        "v1.0",                 # mismatch
+        "v2",                   # mismatch
+        "1.0.0-alpha+001",      # mismatch
+        "v1.0.0-rc1+build.1",   # mismatch
+        "2.0.0+build.1848",     # mismatch
+        "2.0.1-alpha.1227",     # mismatch
+        "1.0.0-alpha.beta",     # mismatch
+        "ros_humble-v0.10.2"    # mismatch
+```
+
+## What kind of version update is possible?
+
+- If there is a new version with pattern matched in the vcs-imported repositories, create a PR for each repository, respectively.
+- The valid/invalid version update cases are as follows:
+  - Valid ones (PR must be created):
+
+```plaintext
+    0.0.1  =>  0.0.2    # If `--target patch` or `--target any` is specified
+    1.1.1  =>  1.2.1    # If `--target minor` or `--target any` is specified
+    2.4.3  =>  3.0.0    # If `--target major` or `--target any` is specified
+```
+
+- Invalid ones (PR is not created):
+
+```plaintext
+    main       =>  0.0.1
+    v0.0.1     =>  0.0.2
+    xxx-0.0.1  =>  0.0.9
+    0.0.1-rc1  =>  0.0.2
+```

--- a/create-prs-to-update-vcs-repositories/action.yaml
+++ b/create-prs-to-update-vcs-repositories/action.yaml
@@ -12,6 +12,10 @@ inputs:
     description: Parent directory
     required: false
     default: ./
+  targets:
+    description: Target release types
+    required: false
+    default: any
   base_branch:
     description: Base branch
     required: false
@@ -63,6 +67,7 @@ runs:
         python ${GITHUB_ACTION_PATH}/create_prs_to_update_vcs_repositories.py \
         --repo_name ${{ inputs.repo_name }} \
         --parent_dir ${{ inputs.parent_dir }} \
+        --targets ${{ inputs.targets }} \
         --base_branch ${{ inputs.base_branch }} \
         --new_branch_prefix ${{ inputs.new_branch_prefix }} \
         --autoware_repos_file_name ${{ inputs.autoware_repos_file_name }} \

--- a/delete-closed-pr-docs/README.md
+++ b/delete-closed-pr-docs/README.md
@@ -7,7 +7,7 @@ This action deletes documents of closed pull requests deployed by `deploy-docs` 
 ```yaml
 jobs:
   delete-closed-pr-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/deploy-docs/README.md
+++ b/deploy-docs/README.md
@@ -9,7 +9,7 @@ Note that this workflow installs the limited number of plugins that are used in 
 ```yaml
 jobs:
   deploy-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -9,7 +9,7 @@ This action generates the changelog using [git-cliff](https://github.com/orhun/g
 ```yaml
 jobs:
   generate-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/get-modified-packages/README.md
+++ b/get-modified-packages/README.md
@@ -9,7 +9,7 @@ This action get the list of ROS packages modified in the pull request.
 ```yaml
 jobs:
   get-modified-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
 ```yaml
 jobs:
   get-modified-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set PR fetch depth
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"

--- a/get-self-packages/README.md
+++ b/get-self-packages/README.md
@@ -7,7 +7,7 @@ This action gets the list of ROS packages in the repository.
 ```yaml
 jobs:
   get-self-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/json-schema-check/README.md
+++ b/json-schema-check/README.md
@@ -9,7 +9,7 @@ This action checks if the ROS 2 parameter files (`config/*.param.yaml`) of packa
 ```yaml
 jobs:
   json-schema-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/pre-commit-autoupdate/README.md
+++ b/pre-commit-autoupdate/README.md
@@ -9,7 +9,7 @@ It uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-
 ```yaml
 jobs:
   sync-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -9,7 +9,7 @@ Considering the case that you have both `.pre-commit-config.yaml` and `.pre-comm
 ```yaml
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/register-autonomoustuff-repository/README.md
+++ b/register-autonomoustuff-repository/README.md
@@ -9,7 +9,7 @@ This action sets up the prerequisites for [pacmod3_msgs](https://github.com/astu
 ```yaml
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ros:galactic
     steps:
       - name: Check out repository

--- a/remove-exec-depend/README.md
+++ b/remove-exec-depend/README.md
@@ -8,7 +8,7 @@ Refer to [here](https://github.com/autowarefoundation/autoware.universe/issues/1
 ```yaml
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ros:galactic
     steps:
       - name: Check out repository

--- a/set-cuda-path/README.md
+++ b/set-cuda-path/README.md
@@ -7,7 +7,7 @@ This action set the CUDA path into GITHUB_ENV amd GITHUB_PATH.
 ```yaml
 jobs:
   set-cuda-path:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/set-git-config/README.md
+++ b/set-git-config/README.md
@@ -13,7 +13,7 @@ This action sets several git configs.
 ```yaml
 jobs:
   example:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/spell-check/README.md
+++ b/spell-check/README.md
@@ -10,7 +10,7 @@ As it is difficult to perfectly detect all miss spellings, it is recommended not
 ```yaml
 jobs:
   spell-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/sync-branches/README.md
+++ b/sync-branches/README.md
@@ -12,7 +12,7 @@ Note that you need `workflow` permission for the token if you copy workflow file
 ```yaml
 jobs:
   sync-branches:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/sync-files/README.md
+++ b/sync-files/README.md
@@ -41,7 +41,7 @@ For this action to work properly, the following settings are required in the tar
 ```yaml
 jobs:
   sync-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/update-codeowners-from-packages/README.md
+++ b/update-codeowners-from-packages/README.md
@@ -12,7 +12,7 @@ Note that you need `workflow` permission for the token if you copy workflow file
 ```yaml
 jobs:
   update-codeowners-from-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Description

Fixes to use Ubuntu 22.04 OS on the Girhub actions.

## Related links

[Ubuntu-latest workflows will use Ubuntu-24.04 image](https://github.com/actions/runner-images/issues/10636)

## Tests performed

~~Will be updated after the PR author checks if the change works.~~

Verified that using `ubuntu-22.04` works by watching running actions with `runs-on: ubuntu-22.04`.

## Notes for reviewers

Nothing to note here.

## Interface changes

No change in this PR.

### ROS Topic Changes

No ROS topic change in this PR.

### ROS Parameter Changes

No ROS parameter changes in this PR.

## Effects on system behavior

The Github actions will run as up to now.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
