### PR TITLE
fix(clang-tidy): exclude test and example directories from clang-tidy check

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -116,7 +116,7 @@ runs:
           target_files="${{ inputs.target-files }}"
         else
           package_path=$(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
-          target_files=$(find $package_path -name "*.cpp" -or -name "*.hpp")
+          target_files=$(find $package_path -type f \( -name '*.cpp' -o -name '*.hpp' \) -not -path '*/test/*' -not -path '*/examples/*')
         fi
 
         echo "target-files=$target_files" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

Excluded `test` and `examples` directories from clang-tidy checks.
They are not necessary to be analyzed.

## Tests performed

Checked locally whether the new command can really exclude those directories.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
