### PR TITLE
feat(clang-tidy): introducing .clang-tidy-ignore

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -8,6 +8,10 @@ inputs:
   clang-tidy-config-url:
     description: ""
     required: true
+  clang-tidy-ignore-path:
+    description: ""
+    required: false
+    default: ".clang-tidy-ignore"
   target-packages:
     description: ""
     required: true
@@ -112,7 +116,7 @@ runs:
           mapfile -t package_paths < <(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
           ignore_patterns=()
           ignore_patterns+=( -not -path "*/test/*" )
-          if [ -f .clang-tidy-ignore ]; then
+          if [ -f ${{ inputs.clang-tidy-ignore-path }} ]; then
             while IFS= read -r pattern; do
               ignore_patterns+=( -not -path "$pattern" )
             done < .clang-tidy-ignore

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -11,7 +11,7 @@ inputs:
   clang-tidy-ignore-path:
     description: ""
     required: false
-    default: ".clang-tidy-ignore"
+    default: .clang-tidy-ignore
   target-packages:
     description: ""
     required: true

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -36,12 +36,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Show targets
-      run: |
-        echo "target packages: ${{ inputs.target-packages }}"
-        echo "target files: ${{ inputs.target-files }}"
-      shell: bash
-
     - name: Install curl
       run: |
         sudo apt-get -yqq update
@@ -115,28 +109,43 @@ runs:
         if [ "${{ inputs.target-files }}" != "" ]; then
           target_files="${{ inputs.target-files }}"
         else
-          package_path=$(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
-          target_files=$(find $package_path -type f \( -name '*.cpp' -o -name '*.hpp' \) -not -path '*/test/*' -not -path '*/examples/*')
+          mapfile -t package_paths < <(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
+          ignore_patterns=()
+          ignore_patterns+=( -not -path "*/test/*" )
+          if [ -f .clang-tidy-ignore ]; then
+            while IFS= read -r pattern; do
+              ignore_patterns+=( -not -path "$pattern" )
+            done < .clang-tidy-ignore
+          fi
+          target_files=$(find "${package_paths[@]}" -name '*.cpp' "${ignore_patterns[@]}" | tr '\n' ' ')
         fi
-
         echo "target-files=$target_files" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Show target files
+      if: ${{ steps.get-target-files.outputs.target-files != '' }}
+      run: |
+        echo "Target files:"
+        for file in "${{ steps.get-target-files.outputs.target-files }}" ; do
+          echo $file
+        done
       shell: bash
 
     - name: Analyze
       if: ${{ steps.get-target-files.outputs.target-files != '' }}
       run: |
         mkdir /tmp/clang-tidy-result
-        clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.txt || true
+        run-clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml -j $(nproc) ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.log || true
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt
       shell: bash
 
-    - name: Check if the report.txt file exists
+    - name: Check if the report.log file exists
       id: check-report-txt-existence
       uses: autowarefoundation/autoware-github-actions/check-file-existence@v1
       with:
-        files: /tmp/clang-tidy-result/report.txt
+        files: /tmp/clang-tidy-result/report.log
 
     - name: Check if the fixes.yaml file exists
       id: check-fixes-yaml-existence
@@ -154,7 +163,7 @@ runs:
     - name: Mark the workflow as failed if clang-tidy find an error
       if: ${{ steps.check-report-txt-existence.outputs.exists == 'true' }}
       run: |
-        if [ -n "$(grep ": error:" /tmp/clang-tidy-result/report.txt)" ]; then
+        if [ -n "$(grep ": error:" /tmp/clang-tidy-result/report.log)" ]; then
           exit 1
         fi
       shell: bash


### PR DESCRIPTION
## Description

This PR introduces support for ignoring specific files in `clang-tidy`.  
To achieve this, you can create a `.clang-tidy-ignore` file under your project directory and list file paths or regular expressions for the files you wish to ignore, as shown below:

```
*/examples/*
perception/**
```

Additionally, this PR includes minor changes.

1. Use `run-clang-tidy` instead of `clang-tidy`.  
    - `run-clang-tidy` allows for parallel execution of `clang-tidy`.

2. Change the report file suffix from `.txt` to `.log`.  
    - Most editors (e.g., VS Code) can colorize log files, enhancing their readability.  

## Related links

- https://github.com/autowarefoundation/autoware.universe/pull/9498

## Tests performed

Tested in [this Action](https://github.com/autowarefoundation/autoware.universe/actions/runs/12063019141/job/33639712216).

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
