### PR TITLE
feat(clang-tidy): determine error using exit_code

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -139,7 +139,9 @@ runs:
       if: ${{ steps.get-target-files.outputs.target-files != '' }}
       run: |
         mkdir /tmp/clang-tidy-result
-        run-clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml -j $(nproc) ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.log || true
+        run-clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml -j $(nproc) ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.log && true
+        exit_code=$?
+        echo "exit_code=$exit_code" >> $GITHUB_ENV
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt
@@ -165,9 +167,6 @@ runs:
         path: /tmp/clang-tidy-result/
 
     - name: Mark the workflow as failed if clang-tidy find an error
-      if: ${{ steps.check-report-txt-existence.outputs.exists == 'true' }}
-      run: |
-        if [ -n "$(grep ": error:" /tmp/clang-tidy-result/report.log)" ]; then
-          exit 1
-        fi
+      if: ${{ env.exit_code != '0' }}
+      run: exit 1
       shell: bash

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -140,8 +140,7 @@ runs:
       run: |
         mkdir /tmp/clang-tidy-result
         run-clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml -j $(nproc) ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.log && true
-        exit_code=$?
-        echo "exit_code=$exit_code" >> $GITHUB_ENV
+        echo "exit_code=$?" >> $GITHUB_ENV
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -148,7 +148,7 @@ runs:
       shell: bash
 
     - name: Check if the report.log file exists
-      id: check-report-txt-existence
+      id: check-report-log-existence
       uses: autowarefoundation/autoware-github-actions/check-file-existence@v1
       with:
         files: /tmp/clang-tidy-result/report.log
@@ -160,7 +160,7 @@ runs:
         files: /tmp/clang-tidy-result/fixes.yaml
 
     - name: Upload artifacts
-      if: ${{ steps.check-report-txt-existence.outputs.exists == 'true' && steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+      if: ${{ steps.check-report-log-existence.outputs.exists == 'true' && steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: clang-tidy-result


### PR DESCRIPTION
## Description
Refactored error determination for CI when using run-clang-tidy because it was not working properly.
Instead of looking for errors in the log with `grep`, change to determine them by `exit_code` in run-clang-tidy.

## Related links

## How was this PR tested?

Tested on [this PR](https://github.com/autowarefoundation/autoware.universe/pull/9593).

- [Log of success](https://github.com/autowarefoundation/autoware.universe/actions/runs/12249643124/job/34172511311?pr=9593)
- [Log of Failure](https://github.com/autowarefoundation/autoware.universe/actions/runs/12249643124/job/34171942667?pr=9593)

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior
