### PR TITLE
fix: bugs that the latest tag is not parsed

### DIFF
--- a/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
+++ b/create-prs-to-update-vcs-repositories/create_prs_to_update_vcs_repositories.py
@@ -204,13 +204,13 @@ def get_latest_tag(tags: list[str], current_version: str, target_release: str) -
         if target_release == 'major':
             if parsed_tag.major > current_ver.major:
                 # Only consider tags with a higher major version
-                if latest_tag is None or parsed_tag < version.parse(latest_tag):
+                if latest_tag is None or parsed_tag > version.parse(latest_tag):
                     latest_tag = tag
 
         elif target_release == 'minor':
             if parsed_tag.major == current_ver.major and parsed_tag.minor > current_ver.minor:
                 # Only consider tags with the same major but higher minor version
-                if latest_tag is None or parsed_tag < version.parse(latest_tag):
+                if latest_tag is None or parsed_tag > version.parse(latest_tag):
                     latest_tag = tag
 
         elif target_release == 'patch':
@@ -218,13 +218,13 @@ def get_latest_tag(tags: list[str], current_version: str, target_release: str) -
                 parsed_tag.minor == current_ver.minor and
                 parsed_tag.micro > current_ver.micro):
                 # Only consider tags with the same major and minor but higher patch version
-                if latest_tag is None or parsed_tag < version.parse(latest_tag):
+                if latest_tag is None or parsed_tag > version.parse(latest_tag):
                     latest_tag = tag
 
         elif target_release == 'any':
             # Consider any version newer than the current version
             if parsed_tag > current_ver:
-                if latest_tag is None or parsed_tag < version.parse(latest_tag):
+                if latest_tag is None or parsed_tag > version.parse(latest_tag):
                     latest_tag = tag
 
     return latest_tag


### PR DESCRIPTION
## Description

Fix a bug that the newest tag is not applied for the created PRs.

## Tests performed

The tests are performed by using [this repository](https://github.com/autowarefoundation/autoware_dummy_repository). The used workflow is provided [here](https://github.com/autowarefoundation/autoware_dummy_repository/blob/9c61c2fc504dba0437d368239eb029dcaa959bea/.github/workflows/create-version-update-pr.yaml). Also you can see the result of the workflow from [here](https://github.com/autowarefoundation/autoware_dummy_repository/actions/runs/12410007506).

We verified the following test is passed:

Condition:
- Fix the current version to be `0.0.1`
- On the [target repository](https://github.com/tier4/scenario_simulator_v2), there are tags like:
  - `7.3.3`, `7.3.2`, ... , `0.9.0`, `0.8.0`, ... `0.1.1`, `0.1.0`, and `0.0.1`

What is tested?:
- If we use `--targets major minor patch`, the following update PRs are created
  - `0.0.1` => `7.3.3` [link to the PR](https://github.com/autowarefoundation/autoware_dummy_repository/pull/120)
  - `0.0.1` => `0.9.0` [link to the PR](https://github.com/autowarefoundation/autoware_dummy_repository/pull/121)

## Notes for reviewers

Any proposal and comments are highly appreciated! For example, please let us know missing / effective test strategies for this PR. I'm happy for performing the proposed tests and applying code change proposals, ... etc :+1: 

## Interface changes

No change

### ROS Topic Changes

No change

### ROS Parameter Changes

No change

## Effects on system behavior

Due to the bug fix, some possible version update PRs will be created on the `autowarefoundation/autoware`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
