### PR TITLE
ci(require-label): add new reusable workflow

### DIFF
--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -1,0 +1,35 @@
+name: require-label
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        required: true
+        type: string
+    outputs:
+      result:
+        value: ${{ jobs.require-label.outputs.result }}
+
+jobs:
+  require-label:
+    runs-on: ubuntu-22.04
+    outputs:
+      result: ${{ steps.require-label.outputs.result }}
+    steps:
+      - name: Check if label is present
+        id: check-for-label
+        if: contains(github.event.pull_request.labels.*.name, inputs.label)
+        run: |
+          echo "::notice::Checking for label '${{ inputs.label }}'..."
+          echo "result=true" >> $GITHUB_OUTPUT
+          echo "### Required label '${{ inputs.label }}' is present." >> $GITHUB_STEP_SUMMARY
+        shell: bash
+
+      - name: Fail if label is not present
+        if: steps.check-for-label.outputs.result != 'true'
+        run: |
+          echo "::error::Label '${{ inputs.label }}' is required but not present. Failing the workflow."
+          echo "result=false" >> $GITHUB_OUTPUT
+          echo "### Required label '${{ inputs.label }}' is missing. Workflow failed." >> $GITHUB_STEP_SUMMARY
+          exit 1
+        shell: bash

--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Fail if label is not present
         if: steps.check-for-label.outputs.result != 'true'
         run: |
-          echo "::error::Label '${{ inputs.label }}' is required but not present. Failing the workflow."
+          echo "::error::❌ The label is missing: '${{ inputs.label }}'"
           echo "result=false" >> $GITHUB_OUTPUT
           echo "## 🚨 Missing Required Label" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   require-label:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.require-label.outputs.result }}
     steps:

--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -30,8 +30,14 @@ jobs:
         run: |
           echo "::error::Label '${{ inputs.label }}' is required but not present. Failing the workflow."
           echo "result=false" >> $GITHUB_OUTPUT
-          echo "### 🚨 Workflow failed due to missing label." >> $GITHUB_STEP_SUMMARY
-          echo "💡 Please add the following label to the PR to pass:" >> $GITHUB_STEP_SUMMARY
-          echo "▶️ ${{ inputs.label }}" >> $GITHUB_STEP_SUMMARY
+          echo "## 🚨 Missing Required Label" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "💡 Please add the following label to the pull request to proceed:" >> $GITHUB_STEP_SUMMARY
+          echo "▶️ **${{ inputs.label }}**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "🔍 Current labels on the pull request:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ toJson(github.event.pull_request.labels.*.name) }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           exit 1
         shell: bash

--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -34,10 +34,5 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "💡 Please add the following label to the pull request to proceed:" >> $GITHUB_STEP_SUMMARY
           echo "▶️ **${{ inputs.label }}**" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🔍 Current labels on the pull request:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ toJson(github.event.pull_request.labels.*.name) }}" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           exit 1
         shell: bash

--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -20,9 +20,8 @@ jobs:
         id: check-for-label
         if: contains(github.event.pull_request.labels.*.name, inputs.label)
         run: |
-          echo "::notice::Checking for label '${{ inputs.label }}'..."
           echo "result=true" >> $GITHUB_OUTPUT
-          echo "### Required label '${{ inputs.label }}' is present." >> $GITHUB_STEP_SUMMARY
+          echo "::notice::✅ The label is present: '${{ inputs.label }}'"
         shell: bash
 
       - name: Fail if label is not present

--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -30,6 +30,8 @@ jobs:
         run: |
           echo "::error::Label '${{ inputs.label }}' is required but not present. Failing the workflow."
           echo "result=false" >> $GITHUB_OUTPUT
-          echo "### Required label '${{ inputs.label }}' is missing. Workflow failed." >> $GITHUB_STEP_SUMMARY
+          echo "### 🚨 Workflow failed due to missing label." >> $GITHUB_STEP_SUMMARY
+          echo "💡 Please add the following label to the PR to pass:" >> $GITHUB_STEP_SUMMARY
+          echo "▶️ ${{ inputs.label }}" >> $GITHUB_STEP_SUMMARY
           exit 1
         shell: bash


### PR DESCRIPTION
## Description

🤔 We have [make-sure-label-is-present.yaml](https://github.com/autowarefoundation/autoware-github-actions/blob/main/.github/workflows/make-sure-label-is-present.yaml) but it skips when it cannot find the label and let's the remaining actions decide what to do with the result. Because it doesn't fail, it skips the remaining workflows.

🫤 We also have [prevent-no-label-execution.yaml](https://github.com/autowarefoundation/autoware-github-actions/blob/main/.github/workflows/prevent-no-label-execution.yaml) which has the identical behavior. But this one is only here for legacy reasons, it can get confused when multiple labels are added at the same time.

So we needed a workflow that actually fails when the input label is not present.

`require-label` workflow does just that. It's a slightly modified version of [make-sure-label-is-present.yaml](https://github.com/autowarefoundation/autoware-github-actions/blob/main/.github/workflows/make-sure-label-is-present.yaml) but with additional summary and useful debug output.

## Tests performed

### Failure

- https://github.com/autowarefoundation/autoware.universe/actions/runs/12470261679

![image](https://github.com/user-attachments/assets/1bb35ba5-d410-4a0e-baf1-1bc29f460c88)

![image](https://github.com/user-attachments/assets/360b716f-b5be-4e8d-9195-e27fdef5c90d)

### Success

- https://github.com/autowarefoundation/autoware.universe/actions/runs/12469760090

![image](https://github.com/user-attachments/assets/2b8d9caa-7e17-4d2b-97be-cb57824d462d)

![image](https://github.com/user-attachments/assets/712d7c20-25e6-44f5-a675-d63a1f4dae1b)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
