### PR TITLE
fix(require-label): output the result

### DIFF
--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -9,12 +9,13 @@ on:
     outputs:
       result:
         value: ${{ jobs.require-label.outputs.result }}
+        description: Returns 'true' if the label is present, empty otherwise (cannot return 'false')
 
 jobs:
   require-label:
     runs-on: ubuntu-latest
     outputs:
-      result: ${{ steps.require-label.outputs.result }}
+      result: ${{ steps.check-for-label.outputs.result }}
     steps:
       - name: Check if label is present
         id: check-for-label
@@ -28,7 +29,6 @@ jobs:
         if: steps.check-for-label.outputs.result != 'true'
         run: |
           echo "::error::❌ The label is missing: '${{ inputs.label }}'"
-          echo "result=false" >> $GITHUB_OUTPUT
           echo "## 🚨 Missing Required Label" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "💡 Please add the following label to the pull request to proceed:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

The action was not returning the result due to a mistake in the modified line.

It now refers to the step correctly and returns "true" if successful.
- Description is also updated.
- Unused variable at the failed step is removed too.


### Official docs
- https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-outputs-from-a-reusable-workflow

> ```yaml
> name: Reusable workflow
> 
> on:
>   workflow_call:
>     # Map the workflow outputs to job outputs
>     outputs:
>       firstword:
>         description: "The first output string"
>         value: ${{ jobs.example_job.outputs.output1 }}
>       secondword:
>         description: "The second output string"
>         value: ${{ jobs.example_job.outputs.output2 }}
> 
> jobs:
>   example_job:
>     name: Generate output
>     runs-on: ubuntu-latest
>     # Map the job outputs to step outputs
>     outputs:
>       output1: ${{ steps.step1.outputs.firstword }}
>       output2: ${{ steps.step2.outputs.secondword }}
>     steps:
>       - id: step1
>         run: echo "firstword=hello" >> $GITHUB_OUTPUT
>       - id: step2
>         run: echo "secondword=world" >> $GITHUB_OUTPUT
> ```

## Tests performed

- https://github.com/autowarefoundation/autoware.universe/actions/runs/12548792030 ✅
- https://github.com/autowarefoundation/autoware.universe/actions/runs/12548864873 ✅

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
