### PR TITLE
feat(colcon-build, colcon-test, clang-tidy): add packages-above-repos argument

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -21,6 +21,9 @@ inputs:
   build-depends-repos:
     description: ""
     required: false
+  packages-above-repos:
+    description: ""
+    required: false
   cmake-build-type:
     description: ""
     required: false
@@ -59,7 +62,7 @@ runs:
       shell: bash
 
     - name: Set git config
-      if: ${{ inputs.build-depends-repos != ''}}
+      if: ${{ inputs.build-depends-repos != '' || inputs.packages-above-repos != '' }}
       uses: autowarefoundation/autoware-github-actions/set-git-config@v1
       with:
         token: ${{ inputs.token }}
@@ -69,6 +72,13 @@ runs:
       run: |
         mkdir -p dependency_ws
         vcs import dependency_ws < ${{ inputs.build-depends-repos }}
+      shell: bash
+
+    - name: Clone above dependency packages
+      if: ${{ inputs.packages-above-repos != '' }}
+      run: |
+        mkdir -p dependency_ws
+        vcs import dependency_ws < ${{ inputs.packages-above-repos }}
       shell: bash
 
     - name: Run rosdep install

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -21,9 +21,6 @@ inputs:
   build-depends-repos:
     description: ""
     required: false
-  packages-above-repos:
-    description: ""
-    required: false
   cmake-build-type:
     description: ""
     required: false
@@ -62,7 +59,7 @@ runs:
       shell: bash
 
     - name: Set git config
-      if: ${{ inputs.build-depends-repos != '' || inputs.packages-above-repos != '' }}
+      if: ${{ inputs.build-depends-repos != ''}}
       uses: autowarefoundation/autoware-github-actions/set-git-config@v1
       with:
         token: ${{ inputs.token }}
@@ -72,13 +69,6 @@ runs:
       run: |
         mkdir -p dependency_ws
         vcs import dependency_ws < ${{ inputs.build-depends-repos }}
-      shell: bash
-
-    - name: Clone above dependency packages
-      if: ${{ inputs.packages-above-repos != '' }}
-      run: |
-        mkdir -p dependency_ws
-        vcs import dependency_ws < ${{ inputs.packages-above-repos }}
       shell: bash
 
     - name: Run rosdep install

--- a/colcon-build/README.md
+++ b/colcon-build/README.md
@@ -26,6 +26,7 @@ jobs:
           rosdistro: galactic
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
+          packages-above-repos: packages_above.repos
 ```
 
 ## Inputs
@@ -35,6 +36,7 @@ jobs:
 | rosdistro                    | true     | ROS distro.                                                                                                             |
 | target-packages              | true     | The target packages to build.                                                                                           |
 | build-depends-repos          | false    | The `.repos` file that includes build dependencies.                                                                     |
+| packages-above-repos         | false    | The `.repos` file that includes above build dependencies.                                                               |
 | cmake-build-type             | false    | The value for `CMAKE_BUILD_TYPE`.                                                                                       |
 | token                        | false    | The token for build dependencies.                                                                                       |
 | include-eol-distros          | false    | If true, adds `--include-eol-distros` to `rosdep update`.                                                               |

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -11,6 +11,9 @@ inputs:
   build-depends-repos:
     description: ""
     required: false
+  packages-above-repos:
+    description: ""
+    required: false
   cmake-build-type:
     description: ""
     required: false
@@ -68,6 +71,13 @@ runs:
       run: |
         mkdir -p dependency_ws
         vcs import dependency_ws < ${{ inputs.build-depends-repos }}
+      shell: bash
+
+    - name: Clone above dependency packages
+      if: ${{ inputs.packages-above-repos != '' }}
+      run: |
+        mkdir -p dependency_ws
+        vcs import dependency_ws < ${{ inputs.packages-above-repos }}
       shell: bash
 
     - name: Run rosdep install

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -61,7 +61,7 @@ runs:
       shell: bash
 
     - name: Set git config
-      if: ${{ inputs.build-depends-repos != '' }}
+      if: ${{ inputs.build-depends-repos != '' || inputs.packages-above-repos != '' }}
       uses: autowarefoundation/autoware-github-actions/set-git-config@v1
       with:
         token: ${{ inputs.token }}

--- a/colcon-test/README.md
+++ b/colcon-test/README.md
@@ -27,6 +27,7 @@ jobs:
           rosdistro: galactic
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
+          packages-above-repos: packages_above.repos
 
   test:
     needs: build
@@ -57,6 +58,7 @@ jobs:
           rosdistro: galactic
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
+          packages-above-repos: packages_above.repos
 
       - name: Upload coverage to Codecov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
@@ -70,12 +72,13 @@ jobs:
 
 ## Inputs
 
-| Name                | Required | Description                                         |
-| ------------------- | -------- | --------------------------------------------------- |
-| rosdistro           | true     | ROS distro.                                         |
-| target-packages     | true     | The target packages to test.                        |
-| build-depends-repos | false    | The `.repos` file that includes build dependencies. |
-| token               | false    | The token for build dependencies.                   |
+| Name                 | Required | Description                                               |
+| -------------------- | -------- | --------------------------------------------------------- |
+| rosdistro            | true     | ROS distro.                                               |
+| target-packages      | true     | The target packages to test.                              |
+| build-depends-repos  | false    | The `.repos` file that includes build dependencies.       |
+| packages-above-repos | false    | The `.repos` file that includes above build dependencies. |
+| token                | false    | The token for build dependencies.                         |
 
 ## Outputs
 

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -11,6 +11,9 @@ inputs:
   build-depends-repos:
     description: ""
     required: false
+  packages-above-repos:
+    description: ""
+    required: false
   token:
     description: ""
     required: false
@@ -59,6 +62,13 @@ runs:
       run: |
         mkdir -p dependency_ws
         vcs import dependency_ws < ${{ inputs.build-depends-repos }}
+      shell: bash
+
+    - name: Clone above dependency packages
+      if: ${{ inputs.packages-above-repos != '' }}
+      run: |
+        mkdir -p dependency_ws
+        vcs import dependency_ws < ${{ inputs.packages-above-repos }}
       shell: bash
 
     - name: Run rosdep install

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -52,7 +52,7 @@ runs:
       shell: bash
 
     - name: Set git config
-      if: ${{ inputs.build-depends-repos != '' }}
+      if: ${{ inputs.build-depends-repos != '' || inputs.packages-above-repos != '' }}
       uses: autowarefoundation/autoware-github-actions/set-git-config@v1
       with:
         token: ${{ inputs.token }}


### PR DESCRIPTION
## Description

This PR adds a `packages-above-repos` argument to colcon-build, colcon-test and clang-tidy github actions.
This change is for the following PR, which describes the background.
https://github.com/autowarefoundation/autoware.universe/pull/9854

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

See https://github.com/autowarefoundation/autoware.universe/pull/9854

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
