### PR TITLE
feat(clang-tidy): add clang tidy pr comments

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -158,6 +158,19 @@ runs:
       with:
         files: /tmp/clang-tidy-result/fixes.yaml
 
+    - name: Copy fixes.yaml to access from Docker Container Action
+      if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+      run: |
+        cp /tmp/clang-tidy-result/fixes.yaml fixes.yaml
+      shell: bash
+
+    - name: Run clang-tidy-pr-comments action
+      if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+      uses: platisd/clang-tidy-pr-comments@1.4.0
+      with:
+        github_token: ${{ inputs.token }}
+        clang_tidy_fixes: fixes.yaml
+
     - name: Upload artifacts
       if: ${{ steps.check-report-log-existence.outputs.exists == 'true' && steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
       uses: actions/upload-artifact@v4

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -170,6 +170,7 @@ runs:
       with:
         github_token: ${{ inputs.token }}
         clang_tidy_fixes: fixes.yaml
+        repo_path_prefix: "/__w" # yamllint disable-line
 
     - name: Upload artifacts
       if: ${{ steps.check-report-log-existence.outputs.exists == 'true' && steps.check-fixes-yaml-existence.outputs.exists == 'true' }}


### PR DESCRIPTION
## Description

By using [platisd/clang-tidy-pr-comments](https://github.com/platisd/clang-tidy-pr-comments), we can annotate clang-tidy errors.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
