### PR TITLE
fix(deploy-docs): fix version for plantuml-markdown

### DIFF
--- a/deploy-docs/mkdocs-requirements.txt
+++ b/deploy-docs/mkdocs-requirements.txt
@@ -11,7 +11,7 @@ mkdocs-static-i18n
 mkdocs-video
 mike
 pathspec
-plantuml-markdown
+plantuml-markdown==3.10.4
 pymdown-extensions
 python-markdown-math
 tabulate


### PR DESCRIPTION
## Description

This will fix version for plantuml-markdown package installed through pip.
The latest version is 3.11.0, but it fails with the new PRs: https://github.com/autowarefoundation/autoware-documentation/actions/runs/13175923845/job/36775082449?pr=644

This specifies the version for plantuml-markdown to use the older version 3.10.4 which was working before. 

## Tests performed

Tested with this action:
https://github.com/mitsudome-r/autoware-documentation/actions/runs/13181082692/job/36791752054

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
