### PR TITLE
feat(colcon-build): set the default pre-command to empty

### DIFF
--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -29,7 +29,7 @@ inputs:
   build-pre-command:
     description: Will be prepended to the colcon build command. e.g. "nice -n 19" or "taskset --cpu-list 0-2"
     required: false
-    default: nice -n 19
+    default: ""
   colcon-parallel-workers-flag:
     description: Will be appended to the colcon build command to limit number of packages built in parallel. e.g. "--parallel-workers 3"
     default: ""


### PR DESCRIPTION
## Description

Sets it empty, I probably forgot to remove it before.

Shouldn't break any existing functionality.

Related:
- https://github.com/autowarefoundation/autoware.universe/pull/10198#discussion_r1970847996

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
