### PR TITLE
feat(colcon-build): source /opt/autoware/setup.sh if exists

### DIFF
--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -66,6 +66,15 @@ runs:
         vcs import dependency_ws < ${{ inputs.build-depends-repos }}
       shell: bash
 
+　   - name: Source /opt/autoware//setup.bash if available
+      run: |
+        if [ -f "/opt/autoware/setup.sh" ]; then
+          . /opt/autoware/setup.sh
+        else
+          echo "/opt/autoware/setup.sh not found"
+        fi
+      shell: bash
+
     - name: Run rosdep install
       run: |
         package_paths=$(colcon list -p --packages-above-and-dependencies ${{ inputs.target-packages }} --base-paths . dependency_ws)

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -66,12 +66,12 @@ runs:
         vcs import dependency_ws < ${{ inputs.build-depends-repos }}
       shell: bash
 
-　   - name: Source /opt/autoware//setup.bash if available
+    - name: Source /opt/autoware/setup.bash if available
       run: |
-        if [ -f "/opt/autoware/setup.sh" ]; then
-          . /opt/autoware/setup.sh
+        if [ -f "/opt/autoware/setup.bash" ]; then
+          source /opt/autoware/setup.bash
         else
-          echo "/opt/autoware/setup.sh not found"
+          echo "/opt/autoware/setup.bash not found"
         fi
       shell: bash
 

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -38,8 +38,8 @@ inputs:
     description: Will be exported as MAKEFLAGS environment variable. e.g. "-j 4"
     default: ""
     required: false
-  overlay-workspace:
-    description: Path to the overlay workspace containing setup.sh
+  underlay-workspace:
+    description: Path to the underlay workspace containing setup.sh
     default: /opt/autoware
     required: false
 
@@ -79,8 +79,8 @@ runs:
         else
             rosdep update
         fi
-        if [ -f "${{ inputs.overlay-workspace }}/setup.sh" ]; then
-          . ${{ inputs.overlay-workspace }}/setup.sh
+        if [ -f "${{ inputs.underlay-workspace }}/setup.sh" ]; then
+          . ${{ inputs.underlay-workspace }}/setup.sh
         fi
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
@@ -94,8 +94,8 @@ runs:
     - name: Build
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
-        if [ -f "${{ inputs.overlay-workspace }}/setup.sh" ]; then
-          . ${{ inputs.overlay-workspace }}/setup.sh
+        if [ -f "${{ inputs.underlay-workspace }}/setup.sh" ]; then
+          . ${{ inputs.underlay-workspace }}/setup.sh
         fi
         # Cannot use unshare inside a Docker container, so we just disable
         # DNS lookups instead.

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -38,6 +38,10 @@ inputs:
     description: Will be exported as MAKEFLAGS environment variable. e.g. "-j 4"
     default: ""
     required: false
+  overlay-workspace:
+    description: Path to the overlay workspace containing setup.sh
+    default: /opt/autoware
+    required: false
 
 runs:
   using: composite
@@ -75,8 +79,8 @@ runs:
         else
             rosdep update
         fi
-        if [ -f "/opt/autoware/setup.sh" ]; then
-          . /opt/autoware/setup.sh
+        if [ -f "${{ inputs.overlay-workspace }}/setup.sh" ]; then
+          . ${{ inputs.overlay-workspace }}/setup.sh
         fi
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
@@ -90,8 +94,8 @@ runs:
     - name: Build
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
-        if [ -f "/opt/autoware/setup.sh" ]; then
-          . /opt/autoware/setup.sh
+        if [ -f "${{ inputs.overlay-workspace }}/setup.sh" ]; then
+          . ${{ inputs.overlay-workspace }}/setup.sh
         fi
         # Cannot use unshare inside a Docker container, so we just disable
         # DNS lookups instead.

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -84,6 +84,7 @@ runs:
         else
             rosdep update
         fi
+        source /opt/autoware/setup.bash
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 
@@ -96,6 +97,7 @@ runs:
     - name: Build
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
+        . /opt/autoware/setup.sh
         # Cannot use unshare inside a Docker container, so we just disable
         # DNS lookups instead.
         cat /etc/nsswitch.conf

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -40,7 +40,7 @@ inputs:
     required: false
   underlay-workspace:
     description: Path to the underlay workspace containing setup.sh
-    default: /opt/autoware
+    default: ""
     required: false
 
 runs:

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -66,15 +66,6 @@ runs:
         vcs import dependency_ws < ${{ inputs.build-depends-repos }}
       shell: bash
 
-    - name: Source /opt/autoware/setup.bash if available
-      run: |
-        if [ -f "/opt/autoware/setup.bash" ]; then
-          source /opt/autoware/setup.bash
-        else
-          echo "/opt/autoware/setup.bash not found"
-        fi
-      shell: bash
-
     - name: Run rosdep install
       run: |
         package_paths=$(colcon list -p --packages-above-and-dependencies ${{ inputs.target-packages }} --base-paths . dependency_ws)
@@ -84,7 +75,9 @@ runs:
         else
             rosdep update
         fi
-        source /opt/autoware/setup.bash
+        if [ -f "/opt/autoware/setup.sh" ]; then
+          . /opt/autoware/setup.sh
+        fi
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 
@@ -97,7 +90,9 @@ runs:
     - name: Build
       run: |
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
-        . /opt/autoware/setup.sh
+        if [ -f "/opt/autoware/setup.sh" ]; then
+          . /opt/autoware/setup.sh
+        fi
         # Cannot use unshare inside a Docker container, so we just disable
         # DNS lookups instead.
         cat /etc/nsswitch.conf


### PR DESCRIPTION
## Description

In the current `autoware` images, the build artifacts of Autoware are saved under `/opt/autoware`. 

https://github.com/autowarefoundation/autoware/blob/main/docker/Dockerfile#L158
https://github.com/autowarefoundation/autoware/blob/main/docker/scripts/build_and_clean.sh#L15

Therefore, in order to reference these artifacts, it is necessary to source `/opt/autoware/setup.sh`.
This PR makes that change. By doing so, it is expected to reduce unnecessary repository references in `build_depends.repos` and shorten the build time.

## Tests performed

- https://github.com/youtalk/autoware.core/pull/2
- https://github.com/youtalk/autoware-github-actions/pull/2
- https://github.com/youtalk/autoware.core/actions/runs/13694329844/job/38293387944?pr=2

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
