### PR TITLE
fix(test-composite-actions): update `autoware` image tag

### DIFF
--- a/.github/workflows/test-composite-actions.yaml
+++ b/.github/workflows/test-composite-actions.yaml
@@ -146,7 +146,7 @@ jobs:
       matrix:
         container:
           - ros:humble
-          - ghcr.io/autowarefoundation/autoware:latest-universe-devel
+          - ghcr.io/autowarefoundation/autoware:universe-devel
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

The `autoware:latest-universe-devel` image tag is no longer available. This PR fixes the tag.

## Tests performed

https://github.com/autowarefoundation/autoware-github-actions/actions/runs/13698027694/job/38304826018?pr=338

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
