### PR TITLE
feat: add packages to skip

### DIFF
--- a/colcon-test/README.md
+++ b/colcon-test/README.md
@@ -56,6 +56,7 @@ jobs:
         with:
           rosdistro: galactic
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
+          packages-skip: package_to_skip1 package_to_skip2
           build-depends-repos: build_depends.repos
 
       - name: Upload coverage to Codecov
@@ -74,6 +75,7 @@ jobs:
 | ------------------- | -------- | --------------------------------------------------- |
 | rosdistro           | true     | ROS distro.                                         |
 | target-packages     | true     | The target packages to test.                        |
+| packages-skip       | false    | Packages to skip during testing.                    |
 | build-depends-repos | false    | The `.repos` file that includes build dependencies. |
 | token               | false    | The token for build dependencies.                   |
 

--- a/colcon-test/README.md
+++ b/colcon-test/README.md
@@ -72,6 +72,7 @@ jobs:
 ```
 
 ## Inputs
+
 | Name                 | Required | Description                                               |
 | -------------------- | -------- | --------------------------------------------------------- |
 | rosdistro            | true     | ROS distro.                                               |

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -8,6 +8,10 @@ inputs:
   target-packages:
     description: ""
     required: true
+  packages-skip:
+    description: "Packages to skip during testing"
+    required: false
+    default: ""
   build-depends-repos:
     description: ""
     required: false
@@ -86,9 +90,16 @@ runs:
           --verbose \
           --packages-above ${{ inputs.target-packages }}
 
+        # Build skip packages argument if packages-skip is provided
+        skip_packages_arg=""
+        if [ -n "${{ inputs.packages-skip }}" ]; then
+          skip_packages_arg="--packages-skip ${{ inputs.packages-skip }}"
+        fi
+
         colcon test --event-handlers console_cohesion+ \
           --mixin coverage-pytest \
           --packages-above ${{ inputs.target-packages }} \
+          $skip_packages_arg \
           --executor sequential \
           --return-code-on-test-failure
 

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: ""
     required: true
   packages-skip:
-    description: "Packages to skip during testing"
+    description: Packages to skip during testing
     required: false
     default: ""
   build-depends-repos:

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -82,19 +82,21 @@ runs:
         set -e
         . /opt/ros/${{ inputs.rosdistro }}/setup.sh
 
-        colcon lcov-result --zero-counters \
-          --verbose \
-          --packages-above ${{ inputs.target-packages }}
-
-        colcon lcov-result --initial \
-          --verbose \
-          --packages-above ${{ inputs.target-packages }}
-
         # Build skip packages argument if packages-skip is provided
         skip_packages_arg=""
         if [ -n "${{ inputs.packages-skip }}" ]; then
           skip_packages_arg="--packages-skip ${{ inputs.packages-skip }}"
         fi
+
+        colcon lcov-result --zero-counters \
+          --verbose \
+          --packages-above ${{ inputs.target-packages }} \
+          $skip_packages_arg
+
+        colcon lcov-result --initial \
+          --verbose \
+          --packages-above ${{ inputs.target-packages }} \
+          $skip_packages_arg
 
         colcon test --event-handlers console_cohesion+ \
           --mixin coverage-pytest \
@@ -106,11 +108,13 @@ runs:
         colcon lcov-result \
           --verbose \
           --filter "*/test/*" \
-          --packages-above ${{ inputs.target-packages }} || true
+          --packages-above ${{ inputs.target-packages }} \
+          $skip_packages_arg || true
 
         colcon coveragepy-result \
           --verbose \
-          --packages-above ${{ inputs.target-packages }} || true
+          --packages-above ${{ inputs.target-packages }} \
+          $skip_packages_arg || true
       shell: bash
 
     - name: Check if the lcov coverage file exists


### PR DESCRIPTION
## Description

Sometimes we want to exclude certain packages from testing, because they are vendor packages and not under our control. However, simply removing them from target packages will not always work, because `--packages-above` argument is used and the vendor package might depend on a package that needs is tested. As a solution to this, `packages-skip` argument is introduces. It is not required and with the default value it will not change the workflow, so all of the current users will be unaffected.  

## Tests performed

Tested with the packages skip for packages that do not pass the tests and confirmed that the workflow finishes successfully. 

## Effects on system behavior

Should not affect existing workflow who do not use the parameter. 

## Interface changes

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/