### PR TITLE
fix(colcon-test): source underlay_ws before running rosdep install

### DIFF
--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -88,6 +88,9 @@ runs:
         else
             rosdep update
         fi
+        if [ -f "${{ inputs.underlay-workspace }}/setup.sh" ]; then
+          . ${{ inputs.underlay-workspace }}/setup.sh
+        fi
         DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths ${package_paths} --ignore-src --rosdistro ${{ inputs.rosdistro }}
       shell: bash
 


### PR DESCRIPTION
## Description
This fixes colcon-test action to source underlay_ws before running rosdep install. Otherwise, it will fail to resolve rosdep keys for packages that exists in underlay workspace. 

This is already done in [colcon-build](https://github.com/autowarefoundation/autoware-github-actions/blob/92257e20a635042be7ea724593ee92a390b9b081/colcon-build/action.yaml#L92), but wasn't done in colcon-test action. 

## Tests performed

Test with [this branch](https://github.com/mitsudome-r/tier4_ad_api_adaptor/tree/fix-build-ci) in this action https://github.com/mitsudome-r/tier4_ad_api_adaptor/actions/runs/14378069943/job/40315140715

## Effects on system behavior

Not applicable.

## Interface changes

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
