### PR TITLE
feat: allow remote sync

### DIFF
--- a/sync-branches/README.md
+++ b/sync-branches/README.md
@@ -35,19 +35,22 @@ jobs:
 
 ## Inputs
 
-| Name                   | Required | Description                                           |
-| ---------------------- | -------- | ----------------------------------------------------- |
-| token                  | true     | The token for pull requests.                          |
-| base-branch            | true     | The base branch of the sync PR.                       |
-| sync-pr-branch         | true     | The branch of the sync PR .                           |
-| sync-target-repository | true     | The sync target repository.                           |
-| sync-target-branch     | true     | The sync target branch.                               |
-| pr-title               | true     | Refer to `peter-evans/create-pull-request`.           |
-| pr-labels              | false    | The same as above.                                    |
-| pr-assignees           | false    | The same as above.                                    |
-| pr-reviewers           | false    | The same as above.                                    |
-| auto-merge-method      | false    | Refer to `peter-evans/enable-pull-request-automerge`. |
+| Name                   | Required | Description                                             |
+| ---------------------- | -------- | ------------------------------------------------------- |
+| token                  | true     | The token for pull requests.                            |
+| base-branch            | true     | The base branch of the sync PR.                         |
+| base-repo              | false    | The base repository. Default is the current repository. |
+| sync-pr-branch         | true     | The branch of the sync PR .                             |
+| sync-target-repository | true     | The sync target repository.                             |
+| sync-target-branch     | true     | The sync target branch.                                 |
+| pr-title               | true     | Refer to `peter-evans/create-pull-request`.             |
+| pr-labels              | false    | The same as above.                                      |
+| pr-assignees           | false    | The same as above.                                      |
+| pr-reviewers           | false    | The same as above.                                      |
+| auto-merge-method      | false    | Refer to `peter-evans/enable-pull-request-automerge`.   |
 
 ## Outputs
 
-None.
+| Name             | Description                      |
+| ---------------- | -------------------------------- |
+| pull-request-url | URL of the created pull request. |

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -8,6 +8,9 @@ inputs:
   base-branch:
     description: ""
     required: true
+  base-repo:
+    description: ""
+    required: false
   sync-pr-branch:
     description: ""
     required: true
@@ -43,6 +46,7 @@ runs:
     - name: Check out repository
       uses: actions/checkout@v4
       with:
+        repository: ${{ inputs.base-repo || github.repository }}
         ref: ${{ inputs.base-branch }}
         fetch-depth: 0
 

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -42,7 +42,7 @@ inputs:
 
 outputs:
   pull-request-url:
-    description: "URL of the created pull request"
+    description: URL of the created pull request
     value: ${{ steps.create-pr.outputs.pull-request-url }}
 
 runs:

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -40,6 +40,11 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  pull-request-url:
+    description: "URL of the created pull request"
+    value: ${{ steps.create-pr.outputs.pull-request-url }}
+
 runs:
   using: composite
   steps:

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -54,6 +54,7 @@ runs:
         repository: ${{ inputs.base-repo || github.repository }}
         ref: ${{ inputs.base-branch }}
         fetch-depth: 0
+        token: ${{ inputs.token }}
 
     - name: Set git config
       uses: autowarefoundation/autoware-github-actions/set-git-config@v1


### PR DESCRIPTION
## Description

Sometimes it is useful to be able to sync branches from an outside location of the repo in question. For example, when we try to orchestrate multiple syncs from a centralized location. This PR adds optional `base-repo` input field to achieve the goal of syncing from outside location. 

Additionally, it sets created PR link to the output so that it is available for the caller.

## Tests performed

This PR was tested on existing workflow: [TierIV link](https://github.com/tier4/autoware_launch.xx1/actions/runs/15014560571/job/42189468185)

Also, new functionality is already used from the PR branch in new workflow: [TIER IV link ](https://github.com/tier4/autoware-release-scripts/blob/b5311bc793e546ce4d6457226031d33d6f5ba7d0/.github/workflows/trigger-autoware-update-branch-product.yaml#L228)
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No affect on existing flows as the default behavior is preserved. 

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
