### PR TITLE
feat: add PR body header for sync branches

### DIFF
--- a/sync-branches/README.md
+++ b/sync-branches/README.md
@@ -30,6 +30,7 @@ jobs:
           sync-target-branch: main
           sync-branch: sync-upstream
           pr-title: "chore: sync upstream"
+          pr-body-header: "This PR syncs changes from the upstream repository."
           auto-merge-method: merge
 ```
 
@@ -48,6 +49,7 @@ jobs:
 | pr-assignees           | false    | The same as above.                                      |
 | pr-reviewers           | false    | The same as above.                                      |
 | auto-merge-method      | false    | Refer to `peter-evans/enable-pull-request-automerge`.   |
+| pr-body-header         | false    | Text to prepend before the changelog in PR body.        |
 
 ## Outputs
 

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -39,6 +39,10 @@ inputs:
     description: ""
     required: false
     default: ""
+  pr-body-header:
+    description: Text to prepend before the changelog in PR body
+    required: false
+    default: ""
 
 outputs:
   pull-request-url:
@@ -75,16 +79,24 @@ runs:
       with:
         git-cliff-args: origin/${{ inputs.base-branch }}..HEAD
 
-    - name: Replace PR number to URL
-      id: replace-pr-number-to-url
+    - name: Prepare PR body
+      id: prepare-pr-body
       run: |
-        # Output multiline strings: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+        # Replace PR numbers with URLs
         changelog=$(echo "$CHANGELOG" | sed -r "s|\(#([0-9]+)\)|("${REPO_URL%.git}"/pull/\1)|g")
+
+        # Output multiline strings: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        echo "changelog<<$EOF" >> $GITHUB_OUTPUT
+        echo "body<<$EOF" >> $GITHUB_OUTPUT
+        if [ -n "$PR_BODY_HEADER" ]; then
+          echo "$PR_BODY_HEADER" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+        fi
         echo "$changelog" >> $GITHUB_OUTPUT
         echo "$EOF" >> $GITHUB_OUTPUT
       env:
+        PR_BODY_HEADER: ${{ inputs.pr-body-header }}
         CHANGELOG: ${{ steps.generate-changelog.outputs.changelog }}
         REPO_URL: ${{ inputs.sync-target-repository }}
       shell: bash
@@ -97,7 +109,7 @@ runs:
         base: ${{ inputs.base-branch }}
         branch: ${{ inputs.sync-pr-branch }}
         title: ${{ inputs.pr-title }}
-        body: ${{ steps.replace-pr-number-to-url.outputs.changelog }}
+        body: ${{ steps.prepare-pr-body.outputs.body }}
         labels: ${{ inputs.pr-labels }}
         assignees: ${{ inputs.pr-assignees }}
         reviewers: ${{ inputs.pr-reviewers }}


### PR DESCRIPTION
## Description

This PR enhances the sync-branches GitHub Action by adding a new `pr-body-header` input parameter that allows users to add custom text before the automatically generated changelog in PR descriptions.

### Implementation Details

- Added `pr-body-header` input parameter
- Refactored and renamed the "Replace PR number to URL" step to "Prepare PR body" for better clarity
- Updated documentation in README.md to reflect the new parameter and provide usage examples

### Example Usage

The new parameter allows for better customization of PR descriptions:

```yaml
- name: Run sync-branches
  uses: autowarefoundation/autoware-github-actions/sync-branches@v1
  with:
    token: ${{ steps.generate-token.outputs.token }}
    base-branch: main
    sync-target-repository: https://github.com/autowarefoundation/autoware.git
    sync-target-branch: main
    sync-pr-branch: sync-upstream
    pr-title: "chore: sync upstream"
    pr-body-header: "This PR was triggered by workflow [link](link-to-workflow)"
    auto-merge-method: merge
```

## Tests performed

Tested on this PR: https://github.com/tier4/autoware-release-scripts/pull/127
Created a sync PR with header here : https://github.com/tier4/autoware_launch.xx1/pull/1287

## Effects on system behavior

None, the as the input is not required

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
