### PR TITLE
fix(build-and-test*.yaml): workaround of ROS signing key migration

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -44,7 +44,7 @@ inputs:
 runs:
   using: composite
   steps:
-    # TODO(youtalk): Remove this once ros:humble is updated
+    # TODO(youtalk): Remove this once ros images are updated
     - name: Workaround for ROS signing key issue
       run: |
         rm -f /etc/apt/sources.list.d/ros2-latest.list

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -44,6 +44,20 @@ inputs:
 runs:
   using: composite
   steps:
+    # TODO(youtalk): Remove this once ros:humble is updated
+    - name: Workaround for ROS signing key issue
+      run: |
+        rm -f /etc/apt/sources.list.d/ros2-latest.list
+        rm -f /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+        apt-get update
+        apt-get install -y ca-certificates curl
+        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+        curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo "$VERSION_CODENAME")_all.deb"
+        apt-get update
+        apt-get install -y /tmp/ros2-apt-source.deb
+        rm -f /tmp/ros2-apt-source.deb
+      shell: bash
+
     - name: Install curl
       run: |
         sudo apt-get -yqq update

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -58,7 +58,7 @@ runs:
         echo "target packages: ${{ inputs.target-packages }}"
       shell: bash
 
-    # TODO(youtalk): Remove this once ros:humble is updated
+    # TODO(youtalk): Remove this once ros images are updated
     - name: Workaround for ROS signing key issue
       run: |
         rm -f /etc/apt/sources.list.d/ros2-latest.list

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -58,6 +58,20 @@ runs:
         echo "target packages: ${{ inputs.target-packages }}"
       shell: bash
 
+    # TODO(youtalk): Remove this once ros:humble is updated
+    - name: Workaround for ROS signing key issue
+      run: |
+        rm -f /etc/apt/sources.list.d/ros2-latest.list
+        rm -f /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+        apt-get update
+        apt-get install -y ca-certificates curl
+        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+        curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo "$VERSION_CODENAME")_all.deb"
+        apt-get update
+        apt-get install -y /tmp/ros2-apt-source.deb
+        rm -f /tmp/ros2-apt-source.deb
+      shell: bash
+
     - name: Install pip for rosdep
       run: |
         sudo apt-get -yqq update


### PR DESCRIPTION
## Description

This PR is a workaround of ROS signing key migration problem.
https://discourse.ros.org/t/ros-signing-key-migration-guide/43937/23

Once ros:humble and ros:jazzy are updated, we will revert this PR.

## Tests performed

- https://github.com/autowarefoundation/autoware_internal_msgs/pull/68
- https://github.com/autowarefoundation/autoware_internal_msgs/actions/runs/15408429862

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
