### PR TITLE
fix(bump-new-version): bugs in version control workflows

### DIFF
--- a/bump-new-version/README.md
+++ b/bump-new-version/README.md
@@ -32,7 +32,7 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Run
-        uses: sasakisasaki/autoware-github-actions/release-new-version@testing/release-new-version
+        uses: autowarefoundation/autoware-github-actions/release-new-version@v1
         with:
           github_token: ${{ steps.generate-token.outputs.token }}
           source_branch: main

--- a/bump-new-version/README.md
+++ b/bump-new-version/README.md
@@ -38,7 +38,7 @@ jobs:
           source_branch: main
           target_branch: humble
           bump_version: patch
-          repository_owner: autowarefoundation
+          source_repository: autowarefoundation
 ```
 
 ## Inputs

--- a/bump-new-version/README.md
+++ b/bump-new-version/README.md
@@ -38,18 +38,18 @@ jobs:
           source_branch: main
           target_branch: humble
           bump_version: patch
-          source_repository: autowarefoundation
+          source_repository_owner: autowarefoundation
 ```
 
 ## Inputs
 
-| Name              | Required | Default            | Description                                              |
-| ----------------- | -------- | ------------------ | -------------------------------------------------------- |
-| github_token      | true     |                    | The GitHub token for authentication                      |
-| source_branch     | true     | main               | The branch to merge from                                 |
-| target_branch     | true     | humble             | The branch to merge into (release branch)                |
-| bump_version      | true     | patch              | The type of version bump (patch, minor, major)           |
-| source_repository | false    | autowarefoundation | The owner of the source repository (e.g., fork user/org) |
+| Name                    | Required | Default            | Description                                              |
+| ----------------------- | -------- | ------------------ | -------------------------------------------------------- |
+| github_token            | true     |                    | The GitHub token for authentication                      |
+| source_branch           | true     | main               | The branch to merge from                                 |
+| target_branch           | true     | humble             | The branch to merge into (release branch)                |
+| bump_version            | true     | patch              | The type of version bump (patch, minor, major)           |
+| source_repository_owner | false    | autowarefoundation | The owner of the source repository (e.g., fork user/org) |
 
 ## Outputs
 

--- a/bump-new-version/action.yaml
+++ b/bump-new-version/action.yaml
@@ -22,7 +22,7 @@ inputs:
       - patch
       - minor
       - major
-  repository_owner:
+  source_repository:
     description: The owner of the source repository (e.g., fork user/org)
     required: false
     default: autowarefoundation
@@ -44,9 +44,9 @@ runs:
     - name: Add source remote if from fork
       shell: bash
       run: |
-        if [ "${{ inputs.repository_owner }}" != "${{ github.repository_owner }}" ]; then
-          echo "Using fork: ${{ inputs.repository_owner }}"
-          git remote add source-fork https://github.com/${{ inputs.repository_owner }}/${{ github.event.repository.name }}.git
+        if [ "${{ inputs.source_repository }}" != "${{ github.repository_owner }}" ]; then
+          echo "Using fork: ${{ inputs.source_repository }}"
+          git remote add source-fork https://github.com/${{ inputs.source_repository }}/${{ github.event.repository.name }}.git
           git fetch source-fork ${{ inputs.source_branch }}
         else
           git fetch origin ${{ inputs.source_branch }}
@@ -62,7 +62,7 @@ runs:
     - name: Based on the source branch, create a new working branch for PR
       shell: bash
       run: |
-        if [ "${{ inputs.repository_owner }}" != "${{ github.repository_owner }}" ]; then
+        if [ "${{ inputs.source_repository }}" != "${{ github.repository_owner }}" ]; then
           git checkout -b ${{ steps.generate_branch_name.outputs.branch_name }} source-fork/${{ inputs.source_branch }}
         else
           git checkout -b ${{ steps.generate_branch_name.outputs.branch_name }} origin/${{ inputs.source_branch }}

--- a/bump-new-version/action.yaml
+++ b/bump-new-version/action.yaml
@@ -22,7 +22,7 @@ inputs:
       - patch
       - minor
       - major
-  source_repository:
+  source_repository_owner:
     description: The owner of the source repository (e.g., fork user/org)
     required: false
     default: autowarefoundation
@@ -44,9 +44,9 @@ runs:
     - name: Add source remote if from fork
       shell: bash
       run: |
-        if [ "${{ inputs.source_repository }}" != "${{ github.repository_owner }}" ]; then
-          echo "Using fork: ${{ inputs.source_repository }}"
-          git remote add source-fork https://github.com/${{ inputs.source_repository }}/${{ github.event.repository.name }}.git
+        if [ "${{ inputs.source_repository_owner }}" != "${{ github.repository_owner }}" ]; then
+          echo "Using fork: ${{ inputs.source_repository_owner }}"
+          git remote add source-fork https://github.com/${{ inputs.source_repository_owner }}/${{ github.event.repository.name }}.git
           git fetch source-fork ${{ inputs.source_branch }}
         else
           git fetch origin ${{ inputs.source_branch }}
@@ -62,7 +62,7 @@ runs:
     - name: Based on the source branch, create a new working branch for PR
       shell: bash
       run: |
-        if [ "${{ inputs.source_repository }}" != "${{ github.repository_owner }}" ]; then
+        if [ "${{ inputs.source_repository_owner }}" != "${{ github.repository_owner }}" ]; then
           git checkout -b ${{ steps.generate_branch_name.outputs.branch_name }} source-fork/${{ inputs.source_branch }}
         else
           git checkout -b ${{ steps.generate_branch_name.outputs.branch_name }} origin/${{ inputs.source_branch }}


### PR DESCRIPTION
## Description

Fix following bugs for `bump-new-version` workflow:
- Input variable name is inconsistent that of `README.md`
- Poor description
- Any string can be used for `bump_version`

## Related links

- https://github.com/autowarefoundation/autoware-github-actions/pull/348

## Tests performed

I used the following workflow:
  - https://github.com/autowarefoundation/autoware_dummy_repository/blob/f786d6496ff2873a8ceca5edb32db2bb608c7d39/.github/workflows/bump-new-version.yaml

Then verified the manually triggered workflow succeeded:
- https://github.com/autowarefoundation/autoware_dummy_repository/actions/runs/15411385937
- https://github.com/autowarefoundation/autoware_dummy_repository/actions/runs/15411418128

## Notes for reviewers

:warning: If you are already using the `bump-new-version`, you need to update so it uses not `repository_owner` but `source_repository_owner`. Please see [README.md](https://github.com/sasakisasaki/autoware-github-actions/tree/5c2efe2ae9f857dc184b4bfa547efca431979379/bump-new-version) for more details. :warning: 

As far as I know, following repository is using the `bump-new-version`. I'll create a PR in the `autoware_internal_msgs` so it follows the change by this PR.
- https://github.com/autowarefoundation/autoware_internal_msgs/blob/main/.github/workflows/bump-new-version.yaml

## Effects on system behavior

- Bug fix will be applied for `bump-new-version`
- Need to fix the input argument variable name if you are already using `bump-new-version`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
