### PR TITLE
revert: "fix(build-and-test*.yaml): workaround of ROS signing key migration"

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -44,20 +44,6 @@ inputs:
 runs:
   using: composite
   steps:
-    # TODO(youtalk): Remove this once ros images are updated
-    - name: Workaround for ROS signing key issue
-      run: |
-        rm -f /etc/apt/sources.list.d/ros2-latest.list
-        rm -f /usr/share/keyrings/ros2-latest-archive-keyring.gpg
-        apt-get update
-        apt-get install -y ca-certificates curl
-        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
-        curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo "$VERSION_CODENAME")_all.deb"
-        apt-get update
-        apt-get install -y /tmp/ros2-apt-source.deb
-        rm -f /tmp/ros2-apt-source.deb
-      shell: bash
-
     - name: Install curl
       run: |
         sudo apt-get -yqq update

--- a/colcon-build/action.yaml
+++ b/colcon-build/action.yaml
@@ -58,20 +58,6 @@ runs:
         echo "target packages: ${{ inputs.target-packages }}"
       shell: bash
 
-    # TODO(youtalk): Remove this once ros images are updated
-    - name: Workaround for ROS signing key issue
-      run: |
-        rm -f /etc/apt/sources.list.d/ros2-latest.list
-        rm -f /usr/share/keyrings/ros2-latest-archive-keyring.gpg
-        apt-get update
-        apt-get install -y ca-certificates curl
-        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
-        curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo "$VERSION_CODENAME")_all.deb"
-        apt-get update
-        apt-get install -y /tmp/ros2-apt-source.deb
-        rm -f /tmp/ros2-apt-source.deb
-      shell: bash
-
     - name: Install pip for rosdep
       run: |
         sudo apt-get -yqq update


### PR DESCRIPTION
Reverts autowarefoundation/autoware-github-actions#349
https://discourse.ros.org/t/ros-signing-key-migration-guide/43937/36