### PR TITLE
feat(deploy-docs): fix deploy failure

### DIFF
--- a/deploy-docs/action.yaml
+++ b/deploy-docs/action.yaml
@@ -19,7 +19,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: '3.10'
 
     - name: Install MkDocs
       run: |

--- a/deploy-docs/mkdocs-requirements.txt
+++ b/deploy-docs/mkdocs-requirements.txt
@@ -1,7 +1,7 @@
 fontawesome_markdown
 markdown==3.3.7
 mdx_truly_sane_lists
-mkdocs==1.4.3
+mkdocs==1.6.0
 mkdocs-awesome-pages-plugin==2.9.1
 mkdocs-exclude
 mkdocs-macros-plugin


### PR DESCRIPTION
We found the following issue while deploying the documents.

```
markdown_extensions:
  - pymdownx.emoji:
      emoji_index: !!python/name:material.extensions.emoji.twemoji
      emoji_generator: !!python/name:material.extensions.emoji.to_svg

'mkdocs_material_extensions' is deprecated and will no longer be
supported moving forward. This is the last release.

error: 'type' object is not subscriptable
```

We thought it was related to mkdocs_material, but it doesn't fix even after [the PR](https://github.com/autowarefoundation/autoware-github-actions/pull/354)

After some testing, the issue should come from the Python version. It's fixed after bumping the Python to 3.10.