### PR TITLE
fix(colcon-test): add ignore_errors to lcov config for lcov 2.x

### DIFF
--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -179,7 +179,7 @@ runs:
         lcov_config_arg=""
         if lcov --version 2>/dev/null | grep -qP 'version [2-9]'; then
           cp "$(dpkg -L python3-colcon-lcov-result | grep lcovrc)" /tmp/lcovrc
-          printf '\nignore_errors = mismatch,empty,source\n' >> /tmp/lcovrc
+          printf '\nignore_errors = mismatch,empty,source\nno_external = 1\n' >> /tmp/lcovrc
           lcov_config_arg="--lcov-config-file /tmp/lcovrc"
         fi
 

--- a/colcon-test/action.yaml
+++ b/colcon-test/action.yaml
@@ -174,15 +174,13 @@ runs:
           . ${{ inputs.underlay-workspace }}/setup.sh
         fi
 
-        # lcov 2.x (Ubuntu 24.04 / jazzy) treats mismatch, empty, source,
-        # and gcov issues as hard errors that abort geninfo processing.
-        # These are non-fatal for coverage reporting, so tell lcov to ignore them.
-        # lcov 1.x (Ubuntu 22.04 / humble) is unaffected as it has no strict checks.
-        # See: https://github.com/linux-test-project/lcov/blob/v2.4/man/lcov.1 (--ignore-errors)
-        #      https://github.com/linux-test-project/lcov/blob/v2.4/man/lcovrc.5 (ignore_errors)
-        lcov_major=$(lcov --version 2>/dev/null | grep -oP 'version \K[0-9]+' || echo "0")
-        if [ "$lcov_major" -ge 2 ]; then
-          echo "ignore_errors = mismatch,empty,source,gcov" >> ~/.lcovrc
+        # lcov 2.x treats mismatch/empty/source as hard errors.
+        # Override colcon lcov-result's bundled config to ignore them.
+        lcov_config_arg=""
+        if lcov --version 2>/dev/null | grep -qP 'version [2-9]'; then
+          cp "$(dpkg -L python3-colcon-lcov-result | grep lcovrc)" /tmp/lcovrc
+          printf '\nignore_errors = mismatch,empty,source\n' >> /tmp/lcovrc
+          lcov_config_arg="--lcov-config-file /tmp/lcovrc"
         fi
 
         # Build skip packages argument if packages-skip is provided
@@ -193,11 +191,13 @@ runs:
 
         colcon lcov-result --zero-counters \
           --verbose \
+          $lcov_config_arg \
           --packages-above ${{ inputs.target-packages }} \
           $skip_packages_arg
 
         colcon lcov-result --initial \
           --verbose \
+          $lcov_config_arg \
           --packages-above ${{ inputs.target-packages }} \
           $skip_packages_arg
 
@@ -211,6 +211,7 @@ runs:
         colcon lcov-result \
           --verbose \
           --filter "*/test/*" \
+          $lcov_config_arg \
           --packages-above ${{ inputs.target-packages }} \
           $skip_packages_arg || true
 


### PR DESCRIPTION
- **Parent Issue:** #399
- Copy colcon lcov-result's bundled lcovrc, append `ignore_errors = mismatch,empty,source`, and pass it via `--lcov-config-file` to all `colcon lcov-result` calls
- The previous fix (#400) wrote to `~/.lcovrc`, but colcon lcov-result passes `--config-file` to its own bundled lcovrc, so lcov 2.x never reads `~/.lcovrc`

## Why

`total_coverage.info` is not generated on jazzy because lcov 2.x hard-errors on mismatched gcov data and empty packages. Without it, codecov falls back to the gcov plugin, walks thousands of `.gcno` files on an `ubuntu-latest` runner, and times out. Writing to `~/.lcovrc` did not work because colcon lcov-result passes `--config-file` pointing to its own bundled config, and lcov 2.x skips `$HOME/.lcovrc` when `--config-file` is provided. Using `--lcov-args` also did not fully work because it only reaches the `lcov --capture` call, not the `lcov --add-tracefile` merge step.

---

- Supersedes #400

## Test plan

All three tests use `tf2_geometry_msgs` from `ros2/geometry2` -- a standard ROS 2 package whose GTest macros trigger lcov 2.x mismatch errors. No volume mounts needed.

### 1. Humble baseline (should pass -- lcov 1.x has no strict errors)

<details>
<summary>Single-line (copy-paste)</summary>

```bash
docker run --rm -w /ws ghcr.io/autowarefoundation/autoware:universe-devel bash -c '. /opt/ros/humble/setup.sh && apt-get -yqq update > /dev/null 2>&1 && apt-get -yqq install lcov python3-colcon-lcov-result > /dev/null 2>&1 && colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml 2>/dev/null || true && colcon mixin update default 2>/dev/null && git clone --depth 1 https://github.com/ros2/geometry2.git -b humble 2>/dev/null && rosdep update 2>/dev/null && rosdep install -yqq --from-paths geometry2/tf2_geometry_msgs --ignore-src --rosdistro humble 2>/dev/null && colcon build --packages-select tf2_geometry_msgs --cmake-args -DCMAKE_BUILD_TYPE=Release --mixin coverage-gcc --base-paths geometry2 2>&1 | tail -3 && colcon lcov-result --zero-counters --packages-select tf2_geometry_msgs --verbose 2>&1 | tail -3 && colcon lcov-result --initial --packages-select tf2_geometry_msgs --verbose 2>&1 | tail -3 && colcon test --packages-select tf2_geometry_msgs --executor sequential --return-code-on-test-failure 2>&1 | tail -3 && colcon lcov-result --packages-select tf2_geometry_msgs --verbose --filter "*/test/*" 2>&1 | tail -15 && echo "---" && ls -la lcov/total_coverage.info'
```

</details>

<details>
<summary>Readable breakdown</summary>

```
IMAGE:    ghcr.io/autowarefoundation/autoware:universe-devel
DISTRO:   humble
PACKAGE:  tf2_geometry_msgs (from ros2/geometry2, branch humble)
FIX:      none (not needed for lcov 1.x)
STEPS:    source ros > install lcov + colcon-lcov-result > setup mixin >
          clone geometry2 > rosdep install > build with coverage >
          lcov zero-counters > lcov initial > colcon test >
          lcov result (filter tests) > check total_coverage.info
```

</details>

- [x] `total_coverage.info` exists

### 2. Jazzy without fix (should fail -- reproduces the issue)

<details>
<summary>Single-line (copy-paste)</summary>

```bash
docker run --rm -w /ws ghcr.io/autowarefoundation/autoware:universe-devel-jazzy bash -c '. /opt/ros/jazzy/setup.sh && apt-get -yqq update > /dev/null 2>&1 && apt-get -yqq install lcov python3-colcon-lcov-result > /dev/null 2>&1 && colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml 2>/dev/null || true && colcon mixin update default 2>/dev/null && git clone --depth 1 https://github.com/ros2/geometry2.git -b jazzy 2>/dev/null && rosdep update 2>/dev/null && rosdep install -yqq --from-paths geometry2/tf2_geometry_msgs --ignore-src --rosdistro jazzy 2>/dev/null && colcon build --packages-select tf2_geometry_msgs --cmake-args -DCMAKE_BUILD_TYPE=Release --mixin coverage-gcc --base-paths geometry2 2>&1 | tail -3 && colcon lcov-result --zero-counters --packages-select tf2_geometry_msgs --verbose 2>&1 | tail -3 && colcon lcov-result --initial --packages-select tf2_geometry_msgs --verbose 2>&1 | tail -3 && colcon test --packages-select tf2_geometry_msgs --executor sequential --return-code-on-test-failure 2>&1 | tail -3 && colcon lcov-result --packages-select tf2_geometry_msgs --verbose --filter "*/test/*" 2>&1 | tail -15 && echo "---" && ls -la lcov/total_coverage.info'
```

</details>

<details>
<summary>Readable breakdown</summary>

```
IMAGE:    ghcr.io/autowarefoundation/autoware:universe-devel-jazzy
DISTRO:   jazzy
PACKAGE:  tf2_geometry_msgs (from ros2/geometry2, branch jazzy)
FIX:      none (reproduces the bug)
STEPS:    same as test 1, but with jazzy image/distro/branch
EXPECT:   geninfo ERROR: mismatched end line -> total_coverage.info NOT generated
```

</details>

- [x] `total_coverage.info` does NOT exist (`geninfo ERROR: mismatched end line`)

### 3. Jazzy with fix (should pass)

<details>
<summary>Single-line (copy-paste)</summary>

```bash
docker run --rm -w /ws ghcr.io/autowarefoundation/autoware:universe-devel-jazzy bash -c '. /opt/ros/jazzy/setup.sh && apt-get -yqq update > /dev/null 2>&1 && apt-get -yqq install lcov python3-colcon-lcov-result > /dev/null 2>&1 && colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml 2>/dev/null || true && colcon mixin update default 2>/dev/null && git clone --depth 1 https://github.com/ros2/geometry2.git -b jazzy 2>/dev/null && rosdep update 2>/dev/null && rosdep install -yqq --from-paths geometry2/tf2_geometry_msgs --ignore-src --rosdistro jazzy 2>/dev/null && colcon build --packages-select tf2_geometry_msgs --cmake-args -DCMAKE_BUILD_TYPE=Release --mixin coverage-gcc --base-paths geometry2 2>&1 | tail -3 && cp "$(dpkg -L python3-colcon-lcov-result | grep lcovrc)" /tmp/lcovrc && printf "\nignore_errors = mismatch,empty,source\n" >> /tmp/lcovrc && colcon lcov-result --zero-counters --packages-select tf2_geometry_msgs --verbose --lcov-config-file /tmp/lcovrc 2>&1 | tail -3 && colcon lcov-result --initial --packages-select tf2_geometry_msgs --verbose --lcov-config-file /tmp/lcovrc 2>&1 | tail -3 && colcon test --packages-select tf2_geometry_msgs --executor sequential --return-code-on-test-failure 2>&1 | tail -3 && colcon lcov-result --packages-select tf2_geometry_msgs --verbose --filter "*/test/*" --lcov-config-file /tmp/lcovrc 2>&1 | tail -15 && echo "---" && ls -la lcov/total_coverage.info'
```

</details>

<details>
<summary>Readable breakdown</summary>

```
IMAGE:    ghcr.io/autowarefoundation/autoware:universe-devel-jazzy
DISTRO:   jazzy
PACKAGE:  tf2_geometry_msgs (from ros2/geometry2, branch jazzy)
FIX:      copy bundled lcovrc > append "ignore_errors = mismatch,empty,source" >
          pass --lcov-config-file /tmp/lcovrc to all colcon lcov-result calls
STEPS:    same as test 2, but with the config override applied
EXPECT:   mismatch errors become warnings -> total_coverage.info IS generated
```

</details>

- [x] `total_coverage.info` exists
