### PR TITLE
feat(clang-tidy): add ctcache support for faster CI runs

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -176,10 +176,22 @@ runs:
         if [ "${{ inputs.use-clang-tidy-cache }}" = "true" ]; then
           export CTCACHE_DIR="${GITHUB_WORKSPACE}/.ctcache"
           export CTCACHE_SAVE_OUTPUT=1
+          mkdir -p "$CTCACHE_DIR"
           cache_flag="-clang-tidy-binary clang-tidy-cached"
+          echo "::group::ctcache config"
+          echo "CTCACHE_DIR=$CTCACHE_DIR"
+          echo "Cache entries before: $(find "$CTCACHE_DIR" -type f 2>/dev/null | wc -l)"
+          echo "Cache size before: $(du -sh "$CTCACHE_DIR" 2>/dev/null | cut -f1)"
+          echo "::endgroup::"
         fi
         run-clang-tidy $cache_flag -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml -j $(nproc) ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.log && true
         echo "exit_code=$?" >> $GITHUB_ENV
+        if [ "${{ inputs.use-clang-tidy-cache }}" = "true" ]; then
+          echo "::group::ctcache stats"
+          echo "Cache entries after: $(find "$CTCACHE_DIR" -type f 2>/dev/null | wc -l)"
+          echo "Cache size after: $(du -sh "$CTCACHE_DIR" 2>/dev/null | cut -f1)"
+          echo "::endgroup::"
+        fi
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -170,13 +170,12 @@ runs:
 
     - name: Analyze
       if: ${{ steps.get-target-files.outputs.target-files != '' }}
-      env:
-        CTCACHE_DIR: ${{ inputs.use-clang-tidy-cache == 'true' && '~/.cache/ctcache' || '' }}
-        CTCACHE_SAVE_OUTPUT: ${{ inputs.use-clang-tidy-cache == 'true' && '1' || '' }}
       run: |
         mkdir /tmp/clang-tidy-result
         cache_flag=""
         if [ "${{ inputs.use-clang-tidy-cache }}" = "true" ]; then
+          export CTCACHE_DIR="$HOME/.cache/ctcache"
+          export CTCACHE_SAVE_OUTPUT=1
           cache_flag="-clang-tidy-binary clang-tidy-cached"
         fi
         run-clang-tidy $cache_flag -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml -j $(nproc) ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.log && true

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -44,26 +44,29 @@ inputs:
     description: Name of the artifact to upload
     default: clang-tidy-result
     required: false
+  use-clang-tidy-cache:
+    description: Enable ctcache to cache clang-tidy results for faster subsequent runs
+    default: "false"
+    required: false
 
 runs:
   using: composite
   steps:
-    - name: Install curl
+    - name: Install dependencies
       run: |
         sudo apt-get -yqq update
-        sudo apt-get -yqq install curl
+        sudo apt-get -yqq install curl python3-pip clang-tidy libomp-dev
       shell: bash
 
-    - name: Install pip for rosdep
+    - name: Install ctcache
+      if: ${{ inputs.use-clang-tidy-cache == 'true' }}
       run: |
-        sudo apt-get -yqq update
-        sudo apt-get -yqq install python3-pip
-      shell: bash
-
-    - name: Install Clang-Tidy
-      run: |
-        sudo apt-get -yqq update
-        sudo apt-get -yqq install clang-tidy libomp-dev
+        sudo apt-get -yqq install pipx
+        pipx install git+https://github.com/matus-chochlik/ctcache.git
+        pipx ensurepath
+        export PATH="$HOME/.local/bin:$PATH"
+        printf '#!/bin/bash\nexport PATH="$HOME/.local/bin:$PATH"\nclang-tidy-cache $(which clang-tidy) "$@"\n' > /usr/local/bin/clang-tidy-cached
+        chmod +x /usr/local/bin/clang-tidy-cached
       shell: bash
 
     - name: Set git config
@@ -121,6 +124,22 @@ runs:
           -H "Authorization: token ${{ inputs.token }}"
       shell: bash
 
+    - name: Get clang-tidy version
+      if: ${{ inputs.use-clang-tidy-cache == 'true' }}
+      id: clang-tidy-version
+      run: |
+        echo "hash=$(clang-tidy --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Restore clang-tidy cache
+      if: ${{ inputs.use-clang-tidy-cache == 'true' }}
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.cache/ctcache
+        key: clang-tidy-cache-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ steps.clang-tidy-version.outputs.hash }}-${{ hashFiles('.clang-tidy') }}-${{ github.sha }}
+        restore-keys: |
+          clang-tidy-cache-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ steps.clang-tidy-version.outputs.hash }}-${{ hashFiles('.clang-tidy') }}-
+
     - name: Get target files
       id: get-target-files
       run: |
@@ -151,14 +170,28 @@ runs:
 
     - name: Analyze
       if: ${{ steps.get-target-files.outputs.target-files != '' }}
+      env:
+        CTCACHE_DIR: ${{ inputs.use-clang-tidy-cache == 'true' && '~/.cache/ctcache' || '' }}
+        CTCACHE_SAVE_OUTPUT: ${{ inputs.use-clang-tidy-cache == 'true' && '1' || '' }}
       run: |
         mkdir /tmp/clang-tidy-result
-        run-clang-tidy -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml -j $(nproc) ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.log && true
+        cache_flag=""
+        if [ "${{ inputs.use-clang-tidy-cache }}" = "true" ]; then
+          cache_flag="-clang-tidy-binary clang-tidy-cached"
+        fi
+        run-clang-tidy $cache_flag -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml -j $(nproc) ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.log && true
         echo "exit_code=$?" >> $GITHUB_ENV
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > /tmp/clang-tidy-result/pr-head-ref.txt
       shell: bash
+
+    - name: Save clang-tidy cache
+      if: ${{ inputs.use-clang-tidy-cache == 'true' }}
+      uses: actions/cache/save@v5
+      with:
+        path: ~/.cache/ctcache
+        key: clang-tidy-cache-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ steps.clang-tidy-version.outputs.hash }}-${{ hashFiles('.clang-tidy') }}-${{ github.sha }}
 
     - name: Check if the report.log file exists
       id: check-report-log-existence

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -135,7 +135,7 @@ runs:
       if: ${{ inputs.use-clang-tidy-cache == 'true' }}
       uses: actions/cache/restore@v5
       with:
-        path: ~/.cache/ctcache
+        path: ${{ github.workspace }}/.ctcache
         key: clang-tidy-cache-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ steps.clang-tidy-version.outputs.hash }}-${{ hashFiles('.clang-tidy') }}-${{ github.sha }}
         restore-keys: |
           clang-tidy-cache-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ steps.clang-tidy-version.outputs.hash }}-${{ hashFiles('.clang-tidy') }}-
@@ -174,7 +174,7 @@ runs:
         mkdir /tmp/clang-tidy-result
         cache_flag=""
         if [ "${{ inputs.use-clang-tidy-cache }}" = "true" ]; then
-          export CTCACHE_DIR="$HOME/.cache/ctcache"
+          export CTCACHE_DIR="${GITHUB_WORKSPACE}/.ctcache"
           export CTCACHE_SAVE_OUTPUT=1
           cache_flag="-clang-tidy-binary clang-tidy-cached"
         fi
@@ -189,7 +189,7 @@ runs:
       if: ${{ inputs.use-clang-tidy-cache == 'true' }}
       uses: actions/cache/save@v5
       with:
-        path: ~/.cache/ctcache
+        path: ${{ github.workspace }}/.ctcache
         key: clang-tidy-cache-${{ runner.arch }}-${{ inputs.rosdistro }}-${{ steps.clang-tidy-version.outputs.hash }}-${{ hashFiles('.clang-tidy') }}-${{ github.sha }}
 
     - name: Check if the report.log file exists


### PR DESCRIPTION
- **Parent Issue:** #402
- Add optional `use-clang-tidy-cache` input to the clang-tidy action that enables [ctcache](https://github.com/matus-chochlik/ctcache) for caching analysis results across runs
- Consolidate three separate apt-get install steps into one
- Cache key includes clang-tidy version hash to ensure correct invalidation on toolchain upgrades

## Why

The clang-tidy action runs full analysis on every invocation, taking 2+ hours on large repos like autoware_universe. With ctcache, only changed files are re-analyzed on subsequent runs, reducing CI wall time from hours to minutes.

## CI benchmark ([autoware_universe#12435](https://github.com/autowarefoundation/autoware_universe/pull/12435), 25 files, 3 packages)

| Run | Analysis time | Cache hits | Cache entries |
|-----|--------------|------------|---------------|
| [Run 4](https://github.com/autowarefoundation/autoware_universe/actions/runs/24140847369) (cold) | 1m 45s | 0/25 | 0 -> 51 |
| [Run 5](https://github.com/autowarefoundation/autoware_universe/actions/runs/24145922209) (warm) | **18s** | **25/25** | 51 -> 51 |

**~6x speedup** with warm cache.

## Local benchmark (autoware_universe, 1095 .cpp files)

| Run | Time | Speedup |
|-----|------|---------|
| Cold cache | 22m 33s | - |
| Warm cache | 2m 28s | ~9x |

---

- Closes #402

## Test plan

- [x] Create a test branch on autoware_universe that references `autowarefoundation/autoware-github-actions@feat/clang-tidy-cache` with `use-clang-tidy-cache: true`
- [x] First run completes successfully and saves the cache (51 entries, 308K)
- [x] Second run restores the cache and skips unchanged files (0 files analyzed, 18s vs 1m 45s)
- [x] Verify clang-tidy findings are still correctly reported