### PR TITLE
feat(clang-tidy): add cache pruning for full-repo runs

### DIFF
--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -48,6 +48,10 @@ inputs:
     description: Enable ctcache to cache clang-tidy results for faster subsequent runs
     default: "false"
     required: false
+  clang-tidy-cache-prune:
+    description: Remove stale cache entries not accessed during this run (enable only for full-repo runs e.g. main branch)
+    default: "false"
+    required: false
 
 runs:
   using: composite
@@ -184,13 +188,24 @@ runs:
           echo "Cache size before: $(du -sh "$CTCACHE_DIR" 2>/dev/null | cut -f1)"
           echo "::endgroup::"
         fi
+        touch /tmp/.ctcache-marker
         run-clang-tidy $cache_flag -p build/ -export-fixes /tmp/clang-tidy-result/fixes.yaml -j $(nproc) ${{ steps.get-target-files.outputs.target-files }} > /tmp/clang-tidy-result/report.log && true
         echo "exit_code=$?" >> $GITHUB_ENV
         if [ "${{ inputs.use-clang-tidy-cache }}" = "true" ]; then
-          echo "::group::ctcache stats"
-          echo "Cache entries after: $(find "$CTCACHE_DIR" -type f 2>/dev/null | wc -l)"
-          echo "Cache size after: $(du -sh "$CTCACHE_DIR" 2>/dev/null | cut -f1)"
+          echo "::group::ctcache stats after analysis"
+          echo "Cache entries: $(find "$CTCACHE_DIR" -type f 2>/dev/null | wc -l)"
+          echo "Cache size: $(du -sh "$CTCACHE_DIR" 2>/dev/null | cut -f1)"
           echo "::endgroup::"
+          if [ "${{ inputs.clang-tidy-cache-prune }}" = "true" ]; then
+            echo "::group::ctcache prune"
+            stale_count=$(find "$CTCACHE_DIR" -type f -not -newer /tmp/.ctcache-marker 2>/dev/null | wc -l)
+            echo "Pruning $stale_count stale cache entries not accessed during this run"
+            find "$CTCACHE_DIR" -type f -not -newer /tmp/.ctcache-marker -delete 2>/dev/null
+            find "$CTCACHE_DIR" -type d -empty -delete 2>/dev/null
+            echo "Cache entries after prune: $(find "$CTCACHE_DIR" -type f 2>/dev/null | wc -l)"
+            echo "Cache size after prune: $(du -sh "$CTCACHE_DIR" 2>/dev/null | cut -f1)"
+            echo "::endgroup::"
+          fi
         fi
         echo "${{ github.event.number }}" > /tmp/clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > /tmp/clang-tidy-result/pr-head-repo.txt


### PR DESCRIPTION
- **Parent Issue:** #402
- Add `clang-tidy-cache-prune` input that removes stale ctcache entries not accessed during the current run
- Uses a timestamp marker before analysis to identify entries that were not hit by ctcache
- Includes grouped diagnostic logging showing cache entries/size before analysis, after analysis, and after prune

## Why

The ctcache directory grows over time as files are added, renamed, or deleted across commits. In practice the full-repo cache is only ~7 MB so this is not urgent, but it's cheap to keep tidy. This input is intended for main branch runs that analyze all files — PR runs that only touch a subset should not prune, since they wouldn't access entries for files outside their scope.

---

- Builds on #403

## Test plan

- [ ] Monitor cache size over several main branch runs before enabling pruning
- [ ] Once growth is observed, enable `clang-tidy-cache-prune: true` on a main branch run and verify the `ctcache prune` log group shows correct stale entry removal
- [ ] Verify that cache entries accessed during the run survive pruning (compare entry counts before/after)