### PR TITLE
fix(clang-tidy): apply ignore patterns when target-files is provided

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,3 +1,3 @@
 {
-  "words": ["chmln"]
+  "words": ["chmln", "ctcache", "CTCACHE", "mapfile"]
 }

--- a/clang-tidy/action.yaml
+++ b/clang-tidy/action.yaml
@@ -143,18 +143,36 @@ runs:
     - name: Get target files
       id: get-target-files
       run: |
+        # Build ignore patterns (shared by both paths)
+        ignore_patterns=()
+        ignore_patterns+=( "*/test/*" )
+        if [ -f ${{ inputs.clang-tidy-ignore-path }} ]; then
+          while IFS= read -r pattern; do
+            ignore_patterns+=( "$pattern" )
+          done < ${{ inputs.clang-tidy-ignore-path }}
+        fi
+
         if [ "${{ inputs.target-files }}" != "" ]; then
-          target_files="${{ inputs.target-files }}"
+          # Filter the provided target files against ignore patterns
+          filtered_files=""
+          for file in ${{ inputs.target-files }}; do
+            skip=false
+            for pattern in "${ignore_patterns[@]}"; do
+              # shellcheck disable=SC2254
+              case "$file" in $pattern) skip=true; break ;; esac
+            done
+            if [ "$skip" = false ]; then
+              filtered_files="$filtered_files $file"
+            fi
+          done
+          target_files="${filtered_files# }"
         else
           mapfile -t package_paths < <(colcon list --paths-only --packages-select ${{ inputs.target-packages }})
-          ignore_patterns=()
-          ignore_patterns+=( -not -path "*/test/*" )
-          if [ -f ${{ inputs.clang-tidy-ignore-path }} ]; then
-            while IFS= read -r pattern; do
-              ignore_patterns+=( -not -path "$pattern" )
-            done < .clang-tidy-ignore
-          fi
-          target_files=$(find "${package_paths[@]}" -name '*.cpp' "${ignore_patterns[@]}" | tr '\n' ' ')
+          find_ignore_args=()
+          for pattern in "${ignore_patterns[@]}"; do
+            find_ignore_args+=( -not -path "$pattern" )
+          done
+          target_files=$(find "${package_paths[@]}" -name '*.cpp' "${find_ignore_args[@]}" | tr '\n' ' ')
         fi
         echo "target-files=$target_files" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
## Description

The `.clang-tidy-ignore` patterns and `*/test/*` exclusion were only applied when files were discovered via `find`. When `target-files` was provided directly (e.g. by diff-based workflows), those filters were skipped entirely, forcing callers to duplicate filtering logic at the workflow level.

This PR extracts the ignore pattern loading into a shared block that runs before the branch, then applies the patterns in both paths:
- For `target-files`: iterates the file list and filters each file against the patterns using `case` glob matching
- For the `find` fallback: same behavior as before, using `-not -path` arguments

## How was this PR tested?

Verified the shell logic locally with sample file lists and glob patterns. The `case` statement uses the same glob syntax as the ignore file patterns.

## Notes for reviewers

The `# shellcheck disable=SC2254` comment is needed because the glob pattern variable in `case` must expand unquoted for pattern matching to work.

## Effects on system behavior

Workflows that pass `target-files` will now correctly exclude files matching `.clang-tidy-ignore` and `*/test/*` patterns. Previously excluded files may have been analyzed.

Fixes #405