### PR TITLE
feat(sync-branches): support commit-SHA for sync-target-branch

### DIFF
--- a/sync-branches/README.md
+++ b/sync-branches/README.md
@@ -43,7 +43,7 @@ jobs:
 | base-repo              | false    | The base repository. Default is the current repository. |
 | sync-pr-branch         | true     | The branch of the sync PR .                             |
 | sync-target-repository | true     | The sync target repository.                             |
-| sync-target-branch     | true     | The sync target branch.                                 |
+| sync-target-branch     | true     | The sync target branch name or commit SHA.              |
 | pr-title               | true     | Refer to `peter-evans/create-pull-request`.             |
 | pr-labels              | false    | The same as above.                                      |
 | pr-assignees           | false    | The same as above.                                      |

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -18,7 +18,7 @@ inputs:
     description: ""
     required: true
   sync-target-branch:
-    description: "Branch name or commit SHA on the sync-target repository to mirror."
+    description: Branch name or commit SHA on the sync-target repository to mirror.
     required: true
   pr-title:
     description: ""

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -18,7 +18,7 @@ inputs:
     description: ""
     required: true
   sync-target-branch:
-    description: ""
+    description: "Branch name or commit SHA on the sync-target repository to mirror."
     required: true
   pr-title:
     description: ""
@@ -69,7 +69,11 @@ runs:
       run: |
         git remote add sync-target "${{ inputs.sync-target-repository }}"
         git fetch -pPtf --all
-        git reset --hard "sync-target/${{ inputs.sync-target-branch }}"
+        if git rev-parse --verify "refs/remotes/sync-target/${{ inputs.sync-target-branch }}" >/dev/null 2>&1; then
+          git reset --hard "sync-target/${{ inputs.sync-target-branch }}"
+        else
+          git reset --hard "${{ inputs.sync-target-branch }}"
+        fi
         git remote rm sync-target
       shell: bash
 

--- a/sync-branches/action.yaml
+++ b/sync-branches/action.yaml
@@ -70,9 +70,12 @@ runs:
         git remote add sync-target "${{ inputs.sync-target-repository }}"
         git fetch -pPtf --all
         if git rev-parse --verify "refs/remotes/sync-target/${{ inputs.sync-target-branch }}" >/dev/null 2>&1; then
+          echo "Resolved '${{ inputs.sync-target-branch }}' as remote branch sync-target/${{ inputs.sync-target-branch }}"
           git reset --hard "sync-target/${{ inputs.sync-target-branch }}"
         else
-          git reset --hard "${{ inputs.sync-target-branch }}"
+          resolved=$(git rev-parse --verify "${{ inputs.sync-target-branch }}^{commit}")
+          echo "Resolved '${{ inputs.sync-target-branch }}' as commit/tag ${resolved}"
+          git reset --hard "${resolved}"
         fi
         git remote rm sync-target
       shell: bash


### PR DESCRIPTION
## Description
Allow `sync-branches/action.yaml`'s `sync-target-branch` input to accept either a branch name or a commit SHA, without changing the input shape.

- Updated `sync-target-branch` description to document that it accepts either a branch name or a commit SHA.
- Reworked the `Sync branches` step to auto-detect which kind of ref was passed:
  - If `refs/remotes/sync-target/<input>` resolves after fetching, treat the input as a branch and reset to `sync-target/<input>`.
  - Otherwise, treat the input as a commit SHA (or tag) and `git reset --hard` directly to it. The commit is already in the local object DB from the preceding `git fetch -pPtf --all`.

## Related issues
 - https://github.com/autowarefoundation/autoware/issues/7083
 - https://github.com/autowarefoundation/autoware/issues/7047

## Tests performed

- [x] Run a workflow that passes a branch name to `sync-target-branch` (existing behavior). 
  - triggered action on my fork: https://github.com/mitsudome-r/autoware_core/actions/runs/25226528706/job/73971325289
  - created PR: https://github.com/mitsudome-r/autoware_core/pull/8 
- [x] Run a workflow that passes a commit SHA to `sync-target-branch`.
  - triggered action on my fork: https://github.com/mitsudome-r/autoware_core/actions/runs/25226627392/job/73971654659
  - created PR: https://github.com/mitsudome-r/autoware_core/pull/9


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
